### PR TITLE
chore: gate native logs behind debug flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ You can find more details in the ["Adding custom native code"](https://docs.expo
 The plugin provides props for extra customization. Every time you change the props or plugins, you'll need to rebuild (and `prebuild`) the native app. If no extra properties are added, defaults will be used.
 
 - `debug` (_boolean_): Enable debug logging for the Expo config plugin. You can also set `BLEPLX_PLUGIN_DEBUG=1` (or `true`/`yes`) in your environment to enable logs without changing config. Default `false`.
+- When enabled, this also stamps a runtime-native flag (`BlePlxDebugLogging`) into iOS `Info.plist` and Android `AndroidManifest.xml` metadata so native debug logs can be gated consistently across platforms.
 - `isBackgroundEnabled` (_boolean_): Enable background BLE support on Android. Adds `<uses-feature android:name="android.hardware.bluetooth_le" android:required="true"/>` to the `AndroidManifest.xml`. Default `false`.
 - `neverForLocation` (_boolean_): Set to true only if you can strongly assert that your app never derives physical location from Bluetooth scan results. The location permission will be still required on older Android devices. Note, that some BLE beacons are filtered from the scan results. Android SDK 31+. Default `false`. _WARNING: This parameter is experimental and BLE might not work. Make sure to test before releasing to production._
 - `modes` (_string[]_): Adds iOS `UIBackgroundModes` to the `Info.plist`. Options are: `peripheral`, and `central`. Defaults to undefined.

--- a/android/src/main/java/com/bleplx/converter/DeviceToJsObjectConverter.java
+++ b/android/src/main/java/com/bleplx/converter/DeviceToJsObjectConverter.java
@@ -1,7 +1,5 @@
 package com.bleplx.converter;
 
-import android.util.Log;
-
 import com.bleplx.adapter.Device;
 import com.bleplx.utils.ReadableArrayConverter;
 import com.facebook.react.bridge.Arguments;

--- a/android/src/main/java/com/bleplx/utils/BlePlxDebugLogging.java
+++ b/android/src/main/java/com/bleplx/utils/BlePlxDebugLogging.java
@@ -1,0 +1,51 @@
+package com.bleplx.utils;
+
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+
+public final class BlePlxDebugLogging {
+  private static final String META_DATA_NAME = "BlePlxDebugLogging";
+
+  private static volatile Boolean cachedEnabled = null;
+
+  private BlePlxDebugLogging() {}
+
+  public static boolean isEnabled(Context context) {
+    Boolean local = cachedEnabled;
+    if (local != null) {
+      return local;
+    }
+
+    boolean enabled = false;
+    try {
+      ApplicationInfo appInfo =
+          context
+              .getPackageManager()
+              .getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
+      Bundle metaData = appInfo.metaData;
+      if (metaData != null && metaData.containsKey(META_DATA_NAME)) {
+        Object value = metaData.get(META_DATA_NAME);
+        if (value instanceof Boolean) {
+          enabled = (Boolean) value;
+        } else if (value instanceof String) {
+          String normalized = ((String) value).trim().toLowerCase();
+          enabled = normalized.equals("1") || normalized.equals("true") || normalized.equals("yes");
+        } else if (value instanceof Integer) {
+          enabled = ((Integer) value) != 0;
+        }
+      }
+    } catch (Exception ignored) {
+      enabled = false;
+    }
+
+    cachedEnabled = enabled;
+    return enabled;
+  }
+
+  public static void resetCacheForTests() {
+    cachedEnabled = null;
+  }
+}
+

--- a/ios/BlePlx.m
+++ b/ios/BlePlx.m
@@ -7,6 +7,7 @@
 //
 
 #import "BlePlx.h"
+#import "BlePlxDebugLogging.h"
 
 // Conditionally import Swift header - it may not exist if no Swift code is compiled
 // (e.g., when the Restoration subspec is not included)
@@ -36,7 +37,7 @@ static BOOL _hasAttemptedAdapterRegistration = NO;
 + (void)initialize {
     if (self == [BlePlx class]) {
         // Only run for BlePlx itself, not subclasses
-        NSLog(@"[BlePlx] +initialize called - attempting early adapter registration");
+        BlePlxDebugLog(@"[BlePlx] +initialize called - attempting early adapter registration");
         [self attemptAdapterRegistration];
     }
 }
@@ -47,18 +48,18 @@ static BOOL _hasAttemptedAdapterRegistration = NO;
     if (_hasAttemptedAdapterRegistration) return;
     _hasAttemptedAdapterRegistration = YES;
 
-    NSLog(@"[BlePlx] Attempting to register BlePlxRestorationAdapter");
+    BlePlxDebugLog(@"[BlePlx] Attempting to register BlePlxRestorationAdapter");
     Class adapterClass = NSClassFromString(@"BlePlxRestorationAdapter");
-    NSLog(@"[BlePlx] BlePlxRestorationAdapter class: %@", adapterClass ? @"FOUND" : @"NOT FOUND (Restoration subspec may not be included)");
+    BlePlxDebugLog(@"[BlePlx] BlePlxRestorationAdapter class: %@", adapterClass ? @"FOUND" : @"NOT FOUND (Restoration subspec may not be included)");
     if (adapterClass && [adapterClass respondsToSelector:@selector(register)]) {
-        NSLog(@"[BlePlx] Calling BlePlxRestorationAdapter.register()");
+        BlePlxDebugLog(@"[BlePlx] Calling BlePlxRestorationAdapter.register()");
         #pragma clang diagnostic push
         #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
         [adapterClass performSelector:@selector(register)];
         #pragma clang diagnostic pop
-        NSLog(@"[BlePlx] BlePlxRestorationAdapter.register() completed");
+        BlePlxDebugLog(@"[BlePlx] BlePlxRestorationAdapter.register() completed");
     } else if (adapterClass) {
-        NSLog(@"[BlePlx] WARNING: BlePlxRestorationAdapter found but register selector not available");
+        BlePlxDebugLog(@"[BlePlx] WARNING: BlePlxRestorationAdapter found but register selector not available");
     }
 }
 

--- a/ios/BlePlxDebugLogging.h
+++ b/ios/BlePlxDebugLogging.h
@@ -1,0 +1,6 @@
+#import <Foundation/Foundation.h>
+
+FOUNDATION_EXPORT BOOL BlePlxDebugLoggingEnabled(void);
+
+FOUNDATION_EXPORT void BlePlxDebugLog(NSString *format, ...) NS_FORMAT_FUNCTION(1, 2);
+

--- a/ios/BlePlxDebugLogging.m
+++ b/ios/BlePlxDebugLogging.m
@@ -1,0 +1,33 @@
+#import "BlePlxDebugLogging.h"
+
+static NSString *const kBlePlxDebugLoggingInfoPlistKey = @"BlePlxDebugLogging";
+
+BOOL BlePlxDebugLoggingEnabled(void) {
+  static dispatch_once_t onceToken;
+  static BOOL enabled = NO;
+
+  dispatch_once(&onceToken, ^{
+    id value = [[NSBundle mainBundle] objectForInfoDictionaryKey:kBlePlxDebugLoggingInfoPlistKey];
+    if ([value respondsToSelector:@selector(boolValue)]) {
+      enabled = [value boolValue];
+    } else {
+      enabled = NO;
+    }
+  });
+
+  return enabled;
+}
+
+void BlePlxDebugLog(NSString *format, ...) {
+  if (!BlePlxDebugLoggingEnabled()) {
+    return;
+  }
+
+  va_list args;
+  va_start(args, format);
+  NSString *message = [[NSString alloc] initWithFormat:format arguments:args];
+  va_end(args);
+
+  NSLog(@"%@", message);
+}
+

--- a/ios/Restoration/BlePlxDebugLogging.swift
+++ b/ios/Restoration/BlePlxDebugLogging.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+enum BlePlxDebugLogging {
+  private static let infoPlistKey = "BlePlxDebugLogging"
+
+  static let isEnabled: Bool = {
+    let value = Bundle.main.object(forInfoDictionaryKey: infoPlistKey)
+    if let boolValue = value as? Bool {
+      return boolValue
+    }
+    if let numberValue = value as? NSNumber {
+      return numberValue.boolValue
+    }
+    if let stringValue = value as? String {
+      let normalized = stringValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+      return normalized == "1" || normalized == "true" || normalized == "yes"
+    }
+    return false
+  }()
+
+  static func log(_ message: @autoclosure () -> String) {
+    guard isEnabled else { return }
+    NSLog("%@", message())
+  }
+}
+

--- a/ios/Restoration/BlePlxRestorationAdapter.swift
+++ b/ios/Restoration/BlePlxRestorationAdapter.swift
@@ -116,11 +116,11 @@ public final class BlePlxRestorationAdapter: NSObject {
   ) {
     guard let peripherals = dict[CBCentralManagerRestoredStatePeripheralsKey] as? [CBPeripheral],
           !peripherals.isEmpty else {
-      print("[BlePlxRestorationAdapter] No peripherals to restore")
+      BlePlxDebugLogging.log("[BlePlxRestorationAdapter] No peripherals to restore")
       return
     }
 
-    print("[BlePlxRestorationAdapter] Restoring \(peripherals.count) peripheral(s)")
+    BlePlxDebugLogging.log("[BlePlxRestorationAdapter] Restoring \(peripherals.count) peripheral(s)")
 
     // Recreate a BleClientManager bound to the same restoration ID.
     let manager = BleClientManager(
@@ -140,11 +140,11 @@ public final class BlePlxRestorationAdapter: NSObject {
         deviceId,
         options: [:],
         resolve: { _ in
-          print("[BlePlxRestorationAdapter] ✓ Reconnected to \(deviceId)")
+          BlePlxDebugLogging.log("[BlePlxRestorationAdapter] ✓ Reconnected to \(deviceId)")
         },
         reject: { code, message, error in
           let reason = message ?? error?.localizedDescription ?? "unknown"
-          print("[BlePlxRestorationAdapter] ✗ Failed to reconnect \(deviceId): \(code ?? "-") / \(reason)")
+          BlePlxDebugLogging.log("[BlePlxRestorationAdapter] ✗ Failed to reconnect \(deviceId): \(code ?? "-") / \(reason)")
         }
       )
     }
@@ -155,14 +155,14 @@ public final class BlePlxRestorationAdapter: NSObject {
   /// Register a device-to-adapter route using whichever registry is available.
   private static func registerDeviceRoute(deviceId: String) {
     guard let (registry, name) = findRegistry() else {
-      print("[BlePlxRestorationAdapter] No registry found for device routing")
+      BlePlxDebugLogging.log("[BlePlxRestorationAdapter] No registry found for device routing")
       return
     }
 
     let selector = NSSelectorFromString("registerDevice:forAdapter:")
     if registry.responds(to: selector) {
       _ = registry.perform(selector, with: deviceId, with: BlePlxRestorationAdapter.self)
-      print("[BlePlxRestorationAdapter] Registered device route via \(name)")
+      BlePlxDebugLogging.log("[BlePlxRestorationAdapter] Registered device route via \(name)")
     }
   }
 
@@ -177,12 +177,12 @@ public final class BlePlxRestorationAdapter: NSObject {
   @objc public static func register() {
     // Prevent duplicate registrations
     guard !isRegistered else {
-      print("[BlePlxRestorationAdapter] Already registered - skipping")
+      BlePlxDebugLogging.log("[BlePlxRestorationAdapter] Already registered - skipping")
       return
     }
 
     guard let (registry, name) = findRegistry() else {
-      print("[BlePlxRestorationAdapter] ✗ No restoration registry found")
+      BlePlxDebugLogging.log("[BlePlxRestorationAdapter] ✗ No restoration registry found")
       return
     }
 
@@ -190,9 +190,9 @@ public final class BlePlxRestorationAdapter: NSObject {
     if registry.responds(to: selector) {
       _ = registry.perform(selector, with: BlePlxRestorationAdapter.self)
       isRegistered = true
-      print("[BlePlxRestorationAdapter] ✓ Registered with \(name)")
+      BlePlxDebugLogging.log("[BlePlxRestorationAdapter] ✓ Registered with \(name)")
     } else {
-      print("[BlePlxRestorationAdapter] ✗ \(name) does not respond to registerAdapter:")
+      BlePlxDebugLogging.log("[BlePlxRestorationAdapter] ✗ \(name) does not respond to registerAdapter:")
     }
   }
 }

--- a/ios/Restoration/BleRestorationRegistry.swift
+++ b/ios/Restoration/BleRestorationRegistry.swift
@@ -35,7 +35,7 @@ public final class BlePlxBundledRestorationRegistry: NSObject {
   @objc public static let shared = BlePlxBundledRestorationRegistry()
   private override init() {
     super.init()
-    print("[BlePlxBundledRestorationRegistry] Bundled fallback registry initialized")
+    BlePlxDebugLogging.log("[BlePlxBundledRestorationRegistry] Bundled fallback registry initialized")
   }
 
   // MARK: - Storage
@@ -60,19 +60,21 @@ public final class BlePlxBundledRestorationRegistry: NSObject {
   public func registerAdapter(_ cls: AnyClass) {
     // Verify the class implements the required selector
     guard cls.responds(to: BlePlxBundledRestorationRegistry.handleRestoredSelector) else {
-      print("[BlePlxBundledRestorationRegistry] ✗ \(cls) does not implement handleRestoredWithCentral:willRestoreState:")
+      BlePlxDebugLogging.log(
+        "[BlePlxBundledRestorationRegistry] ✗ \(cls) does not implement handleRestoredWithCentral:willRestoreState:"
+      )
       return
     }
 
     queue.sync(flags: .barrier) {
       // Avoid duplicate registration
       if adapterClasses.contains(where: { $0 === cls }) {
-        print("[BlePlxBundledRestorationRegistry] Already registered: \(cls)")
+        BlePlxDebugLogging.log("[BlePlxBundledRestorationRegistry] Already registered: \(cls)")
         return
       }
 
       adapterClasses.append(cls)
-      print("[BlePlxBundledRestorationRegistry] ✓ Registered \(cls)")
+      BlePlxDebugLogging.log("[BlePlxBundledRestorationRegistry] ✓ Registered \(cls)")
     }
   }
 
@@ -100,7 +102,9 @@ public final class BlePlxBundledRestorationRegistry: NSObject {
   /// BleRestorationRegistry implementation.
   @objc(registerDevice:forAdapter:)
   public func registerDevice(_ deviceId: String, for cls: AnyClass) {
-    print("[BlePlxBundledRestorationRegistry] Device \(deviceId) noted (advanced routing requires host registry)")
+    BlePlxDebugLogging.log(
+      "[BlePlxBundledRestorationRegistry] Device \(deviceId) noted (advanced routing requires host registry)"
+    )
   }
 
   // MARK: - Restoration Dispatch
@@ -114,11 +118,11 @@ public final class BlePlxBundledRestorationRegistry: NSObject {
     let classes = allAdapterClasses
 
     guard !classes.isEmpty else {
-      print("[BlePlxBundledRestorationRegistry] No adapters registered - nothing to restore")
+      BlePlxDebugLogging.log("[BlePlxBundledRestorationRegistry] No adapters registered - nothing to restore")
       return
     }
 
-    print("[BlePlxBundledRestorationRegistry] Dispatching restoration to \(classes.count) adapter(s)")
+    BlePlxDebugLogging.log("[BlePlxBundledRestorationRegistry] Dispatching restoration to \(classes.count) adapter(s)")
 
     for cls in classes {
       // Use ObjC runtime to invoke the class method
@@ -130,9 +134,9 @@ public final class BlePlxBundledRestorationRegistry: NSObject {
         let handleRestored = unsafeBitCast(imp, to: HandleRestoredFunc.self)
         handleRestored(cls, BlePlxBundledRestorationRegistry.handleRestoredSelector, central, dict)
 
-        print("[BlePlxBundledRestorationRegistry] ✓ Dispatched to \(cls)")
+        BlePlxDebugLogging.log("[BlePlxBundledRestorationRegistry] ✓ Dispatched to \(cls)")
       } else {
-        print("[BlePlxBundledRestorationRegistry] ✗ Could not find method on \(cls)")
+        BlePlxDebugLogging.log("[BlePlxBundledRestorationRegistry] ✗ Could not find method on \(cls)")
       }
     }
   }

--- a/plugin/src/__tests__/withBLEDebugLogging-test.ts
+++ b/plugin/src/__tests__/withBLEDebugLogging-test.ts
@@ -39,6 +39,52 @@ describe('setBlePlxDebugLoggingAndroidManifest', () => {
     expect(xml).toMatch(/<meta-data android:name="BlePlxDebugLogging" android:value="false"\/>/)
   })
 
+  it('handles null meta-data gracefully', () => {
+    const androidManifest = {
+      manifest: {
+        application: [
+          {
+            $: { 'android:name': '.MainApplication' },
+            'meta-data': null
+          }
+        ]
+      }
+    }
+
+    const result = setBlePlxDebugLoggingAndroidManifest(androidManifest as any, true)
+
+    const mainApp = AndroidConfig.Manifest.getMainApplicationOrThrow(result)
+    const metaData = mainApp['meta-data']
+
+    expect(Array.isArray(metaData)).toBe(true)
+    expect(metaData).toHaveLength(1)
+    expect(metaData[0].$['android:name']).toBe('BlePlxDebugLogging')
+    expect(metaData[0].$['android:value']).toBe('true')
+  })
+
+  it('handles empty array meta-data', () => {
+    const androidManifest = {
+      manifest: {
+        application: [
+          {
+            $: { 'android:name': '.MainApplication' },
+            'meta-data': []
+          }
+        ]
+      }
+    }
+
+    const result = setBlePlxDebugLoggingAndroidManifest(androidManifest as any, true)
+
+    const mainApp = AndroidConfig.Manifest.getMainApplicationOrThrow(result)
+    const metaData = mainApp['meta-data']
+
+    expect(Array.isArray(metaData)).toBe(true)
+    expect(metaData).toHaveLength(1)
+    expect(metaData[0].$['android:name']).toBe('BlePlxDebugLogging')
+    expect(metaData[0].$['android:value']).toBe('true')
+  })
+
   it('preserves existing meta-data when it is a single object (not array)', () => {
     // Simulate the XML parser returning a single meta-data entry as an object
     const androidManifest = {

--- a/plugin/src/__tests__/withBLEDebugLogging-test.ts
+++ b/plugin/src/__tests__/withBLEDebugLogging-test.ts
@@ -1,0 +1,46 @@
+import { AndroidConfig, XML } from '@expo/config-plugins'
+import { resolve } from 'path'
+
+import { setBlePlxDebugLoggingAndroidManifest, setBlePlxDebugLoggingInfoPlist } from '../withBLEDebugLogging'
+
+const { readAndroidManifestAsync } = AndroidConfig.Manifest
+
+const sampleManifestPath = resolve(__dirname, 'fixtures/AndroidManifest.xml')
+
+describe('setBlePlxDebugLoggingInfoPlist', () => {
+  it('sets BlePlxDebugLogging=true', () => {
+    const infoPlist: Record<string, unknown> = {}
+    setBlePlxDebugLoggingInfoPlist(infoPlist, true)
+    expect(infoPlist.BlePlxDebugLogging).toBe(true)
+  })
+
+  it('sets BlePlxDebugLogging=false', () => {
+    const infoPlist: Record<string, unknown> = { BlePlxDebugLogging: true }
+    setBlePlxDebugLoggingInfoPlist(infoPlist, false)
+    expect(infoPlist.BlePlxDebugLogging).toBe(false)
+  })
+})
+
+describe('setBlePlxDebugLoggingAndroidManifest', () => {
+  it('adds meta-data when missing', async () => {
+    let androidManifest = await readAndroidManifestAsync(sampleManifestPath)
+    androidManifest = setBlePlxDebugLoggingAndroidManifest(androidManifest, true)
+
+    const xml = XML.format(androidManifest)
+    expect(xml).toMatch(/<meta-data android:name="BlePlxDebugLogging" android:value="true"\/>/)
+  })
+
+  it('updates meta-data when present', async () => {
+    let androidManifest = await readAndroidManifestAsync(sampleManifestPath)
+    androidManifest = setBlePlxDebugLoggingAndroidManifest(androidManifest, true)
+    androidManifest = setBlePlxDebugLoggingAndroidManifest(androidManifest, false)
+
+    const xml = XML.format(androidManifest)
+    expect(xml).toMatch(/<meta-data android:name="BlePlxDebugLogging" android:value="false"\/>/)
+  })
+})
+
+jest.mock('expo/config', () => ({
+  getNameFromConfig: () => ({ appName: 'App', webName: 'App' }),
+  getConfig: () => ({ exp: { name: 'App', slug: 'app', web: {}, ios: {}, android: {} } })
+}))

--- a/plugin/src/__tests__/withBLEDebugLogging-test.ts
+++ b/plugin/src/__tests__/withBLEDebugLogging-test.ts
@@ -38,6 +38,42 @@ describe('setBlePlxDebugLoggingAndroidManifest', () => {
     const xml = XML.format(androidManifest)
     expect(xml).toMatch(/<meta-data android:name="BlePlxDebugLogging" android:value="false"\/>/)
   })
+
+  it('preserves existing meta-data when it is a single object (not array)', () => {
+    // Simulate the XML parser returning a single meta-data entry as an object
+    const androidManifest = {
+      manifest: {
+        application: [
+          {
+            $: { 'android:name': '.MainApplication' },
+            'meta-data': {
+              $: {
+                'android:name': 'expo.modules.updates.EXPO_UPDATE_URL',
+                'android:value': 'https://example.com/updates'
+              }
+            }
+          }
+        ]
+      }
+    }
+
+    const result = setBlePlxDebugLoggingAndroidManifest(androidManifest, true)
+
+    const mainApp = AndroidConfig.Manifest.getMainApplicationOrThrow(result)
+    const metaData = mainApp['meta-data']
+
+    // Should now be an array with 2 entries
+    expect(Array.isArray(metaData)).toBe(true)
+    expect(metaData).toHaveLength(2)
+
+    // Original meta-data should be preserved
+    expect(metaData[0].$['android:name']).toBe('expo.modules.updates.EXPO_UPDATE_URL')
+    expect(metaData[0].$['android:value']).toBe('https://example.com/updates')
+
+    // New meta-data should be added
+    expect(metaData[1].$['android:name']).toBe('BlePlxDebugLogging')
+    expect(metaData[1].$['android:value']).toBe('true')
+  })
 })
 
 jest.mock('expo/config', () => ({

--- a/plugin/src/withBLE.ts
+++ b/plugin/src/withBLE.ts
@@ -12,6 +12,7 @@ import { withBLEAndroidManifest } from './withBLEAndroidManifest'
 import { withBLEAndroidForegroundService } from './withBLEAndroidForegroundService'
 import { BackgroundMode, withBLEBackgroundModes } from './withBLEBackgroundModes'
 import { withBluetoothPermissions } from './withBluetoothPermissions'
+import { withBLEDebugLogging } from './withBLEDebugLogging'
 import { withBLERestorationPodfile } from './withBLERestorationPodfile'
 import { blePlxPluginDebugLog, isBlePlxPluginDebugEnabled } from './debugLog'
 
@@ -38,6 +39,8 @@ const withBLE: ConfigPlugin<
   const debugEnabled = isBlePlxPluginDebugEnabled(_props.debug)
   blePlxPluginDebugLog(debugEnabled, 'Plugin running with props:', JSON.stringify(props))
   blePlxPluginDebugLog(debugEnabled, 'Package name from pkg.json:', pkg.name)
+
+  config = withBLEDebugLogging(config, { debugEnabled })
 
   const isBackgroundEnabled = _props.isBackgroundEnabled ?? false
   const neverForLocation = _props.neverForLocation ?? false

--- a/plugin/src/withBLEDebugLogging.ts
+++ b/plugin/src/withBLEDebugLogging.ts
@@ -14,8 +14,11 @@ export function setBlePlxDebugLoggingAndroidManifest(
 ) {
   const mainApplication = AndroidConfig.Manifest.getMainApplicationOrThrow(androidManifest)
 
+  // Ensure meta-data is an array. When there's only one meta-data entry,
+  // the XML parser returns an object instead of an array. We must preserve
+  // existing entries to avoid wiping host app configuration.
   if (!Array.isArray(mainApplication['meta-data'])) {
-    mainApplication['meta-data'] = []
+    mainApplication['meta-data'] = mainApplication['meta-data'] ? [mainApplication['meta-data']] : []
   }
 
   const existing = mainApplication['meta-data'].find(

--- a/plugin/src/withBLEDebugLogging.ts
+++ b/plugin/src/withBLEDebugLogging.ts
@@ -1,0 +1,52 @@
+import { AndroidConfig, withAndroidManifest, withInfoPlist, type ConfigPlugin } from '@expo/config-plugins'
+
+export const BLEPLX_DEBUG_LOGGING_PLIST_KEY = 'BlePlxDebugLogging'
+export const BLEPLX_DEBUG_LOGGING_ANDROID_META_DATA_NAME = 'BlePlxDebugLogging'
+
+export function setBlePlxDebugLoggingInfoPlist(infoPlist: Record<string, unknown>, debugEnabled: boolean) {
+  infoPlist[BLEPLX_DEBUG_LOGGING_PLIST_KEY] = debugEnabled
+  return infoPlist
+}
+
+export function setBlePlxDebugLoggingAndroidManifest(
+  androidManifest: AndroidConfig.Manifest.AndroidManifest,
+  debugEnabled: boolean
+) {
+  const mainApplication = AndroidConfig.Manifest.getMainApplicationOrThrow(androidManifest)
+
+  if (!Array.isArray(mainApplication['meta-data'])) {
+    mainApplication['meta-data'] = []
+  }
+
+  const existing = mainApplication['meta-data'].find(
+    item => item.$?.['android:name'] === BLEPLX_DEBUG_LOGGING_ANDROID_META_DATA_NAME
+  )
+
+  const value = debugEnabled ? 'true' : 'false'
+  if (existing) {
+    existing.$['android:value'] = value
+  } else {
+    mainApplication['meta-data'].push({
+      $: {
+        'android:name': BLEPLX_DEBUG_LOGGING_ANDROID_META_DATA_NAME,
+        'android:value': value
+      }
+    })
+  }
+
+  return androidManifest
+}
+
+export const withBLEDebugLogging: ConfigPlugin<{ debugEnabled: boolean }> = (config, { debugEnabled }) => {
+  config = withInfoPlist(config, config => {
+    setBlePlxDebugLoggingInfoPlist(config.modResults, debugEnabled)
+    return config
+  })
+
+  config = withAndroidManifest(config, config => {
+    setBlePlxDebugLoggingAndroidManifest(config.modResults, debugEnabled)
+    return config
+  })
+
+  return config
+}


### PR DESCRIPTION
This PR gates always-on native debug logs behind a single opt-in debug switch.

Changes:
- Expo config plugin: when debug is enabled (plugin prop `debug: true` or `BLEPLX_PLUGIN_DEBUG=1|true|yes`), stamp `BlePlxDebugLogging` into:
  - iOS `Info.plist`
  - Android `AndroidManifest.xml` `<application>` meta-data
- iOS native: replace unconditional `print(...)`/`NSLog(...)` in restoration + early registration paths with gated logging driven by `BlePlxDebugLogging`.
- Android: add `BlePlxDebugLogging` runtime reader (foundation for gating future Android logs).
- Plugin tests: cover Info.plist + AndroidManifest stamping.

Notes:
- No `console.*` logging is introduced in library runtime; apps opt-in via the debug switch.
- `pnpm typecheck`, `pnpm test:package`, and `pnpm test:plugin` pass locally; lint still has the 3 known empty-catch warnings we agreed to discuss separately.