### PR TITLE
chore: release 3.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [3.8.0] - 2026-07-08
+
+### Added
+
+- React Native 0.86 TurboModule/codegen integration for Android and iOS.
+- Expo SDK 57 CNG example workflow with generated native projects kept out of source control.
+- RN 0.86 / Expo 57 release verification script covering package tests, plugin tests, lint/typecheck, prepack, Expo Doctor, CNG prebuild, and Android assemble.
+- Android and iOS modernization regression tests for platform floors, codegen shape, package metadata, CI ordering, and example configuration.
+
+### Changed
+
+- Raised the supported floor to React Native 0.86, Expo SDK 57, Node 20.19.4+, Android min SDK 24, Android compile/target SDK 36, Android build tools 36.0.0, and iOS deployment target 16.4.
+- Migrated Android registration to `BaseReactPackage` and the modern `react-android` artifact.
+- Migrated iOS source to ObjC++ and generated TurboModule selectors, including typed option structs for scan, connect, and background-mode calls.
+- Converted the Expo example from checked-in native projects to a CNG source workflow using `pnpm`.
+- Updated the non-Expo example to RN 0.86-compatible native dependencies and iOS/Android project settings.
+- Updated package entrypoints to built `lib` outputs and upgraded `react-native-builder-bob` for current package builds.
+- Treated the RN 0.86 TurboModule/Fabric runtime as the default platform posture and removed stale architecture opt-out signals from examples/build logic.
+
+### Fixed
+
+- Fixed reconnect option updates so already scheduled retries use the latest active reconnect options.
+- Fixed Android promise rejection fallbacks so null error messages surface `Unknown error` instead of an empty message.
+- Fixed Expo CI ordering so the local `file:..` dependency is installed after package declarations/artifacts are generated.
+- Fixed iOS generated selector coverage for promise methods and codegen option objects.
+- Fixed Android custom GATT refresh operation typing for modern javac.
+
+### Removed
+
+- Removed checked-in generated `example-expo/android`, `example-expo/ios`, and example Podfile lock outputs.
+- Removed obsolete programmatic Android Bluetooth adapter toggle APIs that are blocked for normal Android 13+ apps.
+- Removed legacy `ConnectionQueue` and `ReconnectionManager` public exports in favor of `ConnectionManager`.
+
 ## [3.5.2] - 2025-11-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ For older React Native versions, use the upstream [dotintent/react-native-ble-pl
 
 ## Version History
 
-**3.8.0 (planned)**
+**3.8.0 (This Fork)**
 
 - Modernized for Expo SDK 57 and React Native 0.86.
 - Uses the generated RN 0.86 TurboModule spec.

--- a/__tests__/AndroidModernization.js
+++ b/__tests__/AndroidModernization.js
@@ -55,6 +55,9 @@ describe('Android modernization defaults', () => {
 
     expect(buildGradle).toContain('apply plugin: "com.facebook.react"')
     expect(buildGradle).toContain('buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", "true"')
+    expect(buildGradle).toContain('react {')
+    expect(buildGradle).toContain('codegenJavaPackageName = "com.bleplx"')
+    expect(buildGradle).not.toContain('isNewArchitectureEnabled')
     expect(buildGradle).not.toContain('newArchEnabled')
     expect(exampleGradleProperties).not.toContain('newArchEnabled')
     expect(mainApplication).toContain('override val isNewArchEnabled: Boolean = true')

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -82,10 +82,8 @@ dependencies {
   implementation "com.polidea.rxandroidble2:rxandroidble:1.17.2"
 }
 
-if (isNewArchitectureEnabled()) {
-  react {
-    jsRootDir = file("../src/")
-    libraryName = "BlePlx"
-    codegenJavaPackageName = "com.bleplx"
-  }
+react {
+  jsRootDir = file("../src/")
+  libraryName = "BlePlx"
+  codegenJavaPackageName = "com.bleplx"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sfourdrinier/react-native-ble-plx",
-  "version": "3.7.10",
+  "version": "3.8.0",
   "description": "React Native Bluetooth Low Energy library",
   "packageManager": "pnpm@10.14.0",
   "main": "lib/commonjs/index.js",


### PR DESCRIPTION
## Summary
- bump package metadata to 3.8.0 and mark the README version history as released
- add the 3.8.0 changelog entry for Expo SDK 57 / React Native 0.86 modernization
- make Android codegen configuration unconditional because RN 0.86 uses the new architecture as the default runtime and no longer needs architecture opt-out branching

## Test Plan
- pnpm verify:release
- pnpm prepack
- npm pack --dry-run --json

## Notes
- generated Expo native projects were moved out by the release gate and are not part of this PR
- real-device BLE/runtime validation remains the only validation not covered by local release automation