### PR TITLE
docs: fix maxRetries semantics and stop shipping broken API HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Fixed package `docs` script to build HTML API docs from `lib/module` (after `prepack`) so documentation.js can parse compiled JS from TypeScript sources; removed broken `documentation lint index.js` from `lint`.
 - Included `docs/` in the published package so npm README relative links resolve (excluding agent-only `docs/superpowers`).
+- Stopped publishing generated `docs/index.html` and `docs/assets` on npm (documentation.js mangles TypeScript enum members in HTML output).
+- Documented `ConnectionManager` `maxRetries` as total connection attempts (including the first), matching the implementation.
 - Expo example identifiers now use the `com.sfourdrinier.bleplxexample` namespace.
 - Expo example `.gitignore` ignores generated CNG `android/` and `ios/` trees.
 - Fixed lefthook pre-commit so lint runs without `@{push}` (broken on new branches).

--- a/__tests__/PackageModernization.js
+++ b/__tests__/PackageModernization.js
@@ -27,6 +27,7 @@ const connectionManager = fs.readFileSync(path.join(__dirname, '..', 'src/Connec
 const connectionQueuePath = path.join(__dirname, '..', 'src/ConnectionQueue.ts')
 const reconnectionManagerPath = path.join(__dirname, '..', 'src/ReconnectionManager.ts')
 const gettingStartedDoc = fs.readFileSync(path.join(__dirname, '..', 'docs/GETTING_STARTED.md'), 'utf8')
+const connectionManagerDoc = fs.readFileSync(path.join(__dirname, '..', 'docs/CONNECTION_MANAGER.md'), 'utf8')
 const exampleExpoGitignore = fs.readFileSync(path.join(__dirname, '..', 'example-expo/.gitignore'), 'utf8')
 const exampleYarnLock = fs.readFileSync(path.join(__dirname, '..', 'example/yarn.lock'), 'utf8')
 const exampleAndroidBuild = fs.readFileSync(path.join(__dirname, '..', 'example/android/build.gradle'), 'utf8')
@@ -322,15 +323,23 @@ describe('package modernization targets', () => {
     expect(readme).not.toContain('We can help you!')
     expect(readme).not.toContain('Contact us at [intent]')
 
-    // Relative README links must resolve for npm consumers (package includes docs/)
+    // Relative README links must resolve for npm consumers (package includes markdown docs/)
     expect(rootPackage.files).toContain('docs')
     expect(rootPackage.files).toContain('!docs/superpowers')
+    // Generated HTML API output is not published: documentation.js mishandles TS enum members.
+    expect(rootPackage.files).toContain('!docs/index.html')
+    expect(rootPackage.files).toContain('!docs/assets')
 
     expect(gettingStartedDoc).toContain('@sfourdrinier/react-native-ble-plx')
     expect(gettingStartedDoc).toMatch(/EXPO_PLUGIN\.md/)
     expect(gettingStartedDoc).toContain('const requestBluetoothPermission')
     expect(gettingStartedDoc).not.toContain('github.com/dotintent/react-native-ble-plx?tab=readme-ov-file#expo-sdk-43')
     expect(gettingStartedDoc).not.toContain('withintent.com')
+
+    // maxRetries is total attempts including the first (not "retries after first only")
+    expect(connectionManagerDoc).toMatch(/Total.*connection attempts|total connection attempts/i)
+    expect(connectionManagerDoc).not.toContain('Attempts after the first try')
+    expect(connectionManager).toMatch(/including the first try/i)
 
     // documentation.js does not extract TS class JSDoc reliably; build from bob's JS output.
     expect(rootPackage.scripts.docs).toContain('lib/module/index.js')

--- a/docs/CONNECTION_MANAGER.md
+++ b/docs/CONNECTION_MANAGER.md
@@ -42,13 +42,13 @@ const device = await connections.connect(deviceId, {
 
 | Option | Default | Meaning |
 | ------ | ------- | ------- |
-| `maxRetries` | `3` | Attempts after the first try (see implementation for exact attempt counting) |
-| `initialDelayMs` | `1000` | Delay before the first retry |
+| `maxRetries` | `3` | **Total** connection attempts, including the first try. `1` = one attempt (no retries); `3` = up to three attempts. |
+| `initialDelayMs` | `1000` | Delay before the first retry after a failed attempt |
 | `maxDelayMs` | `30000` | Cap for exponential backoff |
 | `backoffMultiplier` | `2` | Multiplier applied between retries |
-| `timeoutMs` | `30000` | Per-attempt / connection timeout; `0` disables |
+| `timeoutMs` | `30000` | Per-attempt connection timeout; `0` disables |
 
-Exact retry accounting is covered by `__tests__/ConnectionManager.test.js`. Prefer that test file when behavior detail matters.
+`ConnectionManager` increments an attempt counter before each connect and stops when that count reaches `maxRetries`. See `__tests__/ConnectionManager.test.js` for examples (`maxRetries: 1` is used for single-attempt cases).
 
 ## Auto-reconnect
 

--- a/docs/FORK.md
+++ b/docs/FORK.md
@@ -47,6 +47,11 @@ This repo is developed and released with **pnpm**.
 - `example/` — bare React Native sample
 - `example-expo/` — Expo CNG sample (`android/` / `ios/` are generated, not committed)
 
+## API reference notes
+
+- Prefer TypeScript types from the package (`lib/typescript`) and the markdown guides under `docs/`.
+- `pnpm docs` can generate a local HTML tree via `documentation.js`, but TypeScript enums compile to patterns that tool mishandles (duplicate anchors, missing member names). Generated `docs/index.html` / `docs/assets` are **not** published on npm for that reason.
+
 ## Related docs
 
 - [Getting started](./GETTING_STARTED.md)

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "app.plugin.js",
     "*.podspec",
     "!docs/superpowers",
+    "!docs/index.html",
+    "!docs/assets",
     "!lib/typescript/example",
     "!lib/typescript/example-expo",
     "!ios/build",

--- a/src/ConnectionManager.ts
+++ b/src/ConnectionManager.ts
@@ -13,7 +13,9 @@ export interface ConnectionOptionsWithRetry {
   connectionOptions?: ConnectionOptions
 
   /**
-   * Maximum number of retry attempts (default: 3)
+   * Maximum number of connection attempts, including the first try (default: 3).
+   * Example: `maxRetries: 1` means a single attempt with no retries;
+   * `maxRetries: 3` means up to three total attempts.
    */
   maxRetries?: number
 


### PR DESCRIPTION
## Summary

Follow-up for post-merge Codex review on PR #16.

- Document `ConnectionManager` `maxRetries` as **total connection attempts including the first** (matching implementation and tests).
- Stop publishing generated `docs/index.html` / `docs/assets` on npm (`documentation.js` produces broken duplicate enum anchors from compiled TS enums). Markdown guides under `docs/` remain packaged for README relative links.
- Note this limitation in `docs/FORK.md`.

## Test plan

- [x] `pnpm test:package`
- [x] `pnpm typecheck`
- [x] `npm pack --dry-run --ignore-scripts` includes markdown guides, excludes `docs/index.html` and `docs/assets`
