### PR TITLE
Release 3.8.3: package roadmap and align CocoaPods tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [3.8.3] - 2026-07-18
+
+### Fixed
+
+- Aligned the CocoaPods source tag with GitHub releases (`v3.8.3`), so CocoaPods resolves the exact published release tag.
+- Included the root roadmap in the npm package, so the README and fork documentation links resolve for installed consumers.
+
 ## [3.8.2] - 2026-07-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ For older React Native versions, use the upstream [dotintent/react-native-ble-pl
 
 ## Version History
 
+**3.8.3 (This Fork)**
+
+- Publishes the roadmap referenced by the README and fork documentation.
+- Aligns the CocoaPods source tag with the `v3.8.3` GitHub release tag.
+
 **3.8.2 (This Fork)**
 
 - Fixes the React Native 0.86 TurboModule bridge so non-enumerable native BLE methods, including `createClient`, remain callable at runtime.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,9 +2,9 @@
 
 This fork publishes as `@sfourdrinier/react-native-ble-plx`.
 
-The current release target is `3.8.2`, a React Native 0.86 TurboModule bridge fix. It preserves non-enumerable generated native methods such as `createClient` when constructing the JavaScript BLE module bridge.
+The current release target is `3.8.3`. It packages the roadmap referenced by the npm README and aligns the CocoaPods source tag with the `v3.8.3` GitHub release tag.
 
-Before publishing `3.8.2`, run `pnpm verify:release`, inspect `npm pack --dry-run`, then publish the package with `pnpm publish --access public --no-git-checks`. Verify the registry reports `3.8.2` and tag the exact published commit as `v3.8.2`.
+Before publishing `3.8.3`, run `pnpm verify:release`, inspect `npm pack --dry-run`, then publish the package with `pnpm publish --access public --no-git-checks`. Verify the registry reports `3.8.3` and tag the exact published commit as `v3.8.3`.
 
 The historical `3.8.0` modernization procedure is retained below for its full SDK 57 / React Native 0.86 migration record.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 **Status:** living document  
 **Last updated:** 2026-07  
 **Package floor:** React Native 0.86+, Expo SDK 57+, TypeScript-first TurboModule  
-**Package version at writing:** 3.8.2
+**Package version at writing:** 3.8.3
 
 This roadmap describes how this fork becomes the most modern, reliable, and feature-complete Bluetooth Low Energy library for React Native—and, over time, a multiplatform BLE client (mobile, web, desktop, Linux). It is intentional product planning, not a release schedule. Priorities can shift when real app needs (especially production background reliability) demand it.
 

--- a/__tests__/IosModernization.js
+++ b/__tests__/IosModernization.js
@@ -18,6 +18,7 @@ describe('iOS modernization defaults', () => {
 
   test('points CocoaPods source metadata at this fork', () => {
     expect(podspec).toContain('https://github.com/sfourdrinier/react-native-ble-plx.git')
+    expect(podspec).toContain(':tag => "v#{s.version}"')
     expect(podspec).not.toContain('https://github.com/dotintent/react-native-ble-plx.git')
   })
 

--- a/__tests__/PackageModernization.js
+++ b/__tests__/PackageModernization.js
@@ -300,6 +300,7 @@ describe('package modernization targets', () => {
 
   test('owns documentation and support for this fork', () => {
     const requiredDocs = [
+      'ROADMAP.md',
       'docs/FORK.md',
       'docs/CONNECTION_MANAGER.md',
       'docs/EXPO_PLUGIN.md',
@@ -316,6 +317,7 @@ describe('package modernization targets', () => {
     expect(readme).toContain('docs/EXPO_PLUGIN.md')
     expect(readme).toContain('docs/TVOS.md')
     expect(readme).toContain('docs/GETTING_STARTED.md')
+    expect(readme).toContain('ROADMAP.md')
     expect(readme).toContain('https://github.com/sfourdrinier/react-native-ble-plx/issues')
     expect(readme).not.toContain('withintent.com')
     expect(readme).not.toContain('dotintent.github.io/react-native-ble-plx')
@@ -325,6 +327,7 @@ describe('package modernization targets', () => {
 
     // Relative README links must resolve for npm consumers (package includes markdown docs/)
     expect(rootPackage.files).toContain('docs')
+    expect(rootPackage.files).toContain('ROADMAP.md')
     expect(rootPackage.files).toContain('!docs/superpowers')
     // Generated HTML API output is not published: documentation.js mishandles TS enum members.
     expect(rootPackage.files).toContain('!docs/index.html')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sfourdrinier/react-native-ble-plx",
-  "version": "3.8.2",
+  "version": "3.8.3",
   "description": "React Native Bluetooth Low Energy library",
   "packageManager": "pnpm@10.14.0",
   "main": "lib/commonjs/index.js",
@@ -15,6 +15,7 @@
     "ios",
     "cpp",
     "docs",
+    "ROADMAP.md",
     "plugin/build",
     "app.plugin.js",
     "*.podspec",

--- a/react-native-ble-plx.podspec
+++ b/react-native-ble-plx.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.authors      = package["author"]
 
   s.platforms    = { :ios => "16.4", :tvos => "16.4" }
-  s.source       = { :git => "https://github.com/sfourdrinier/react-native-ble-plx.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/sfourdrinier/react-native-ble-plx.git", :tag => "v#{s.version}" }
 
   # MultiplatformBleAdapter (0.2.0) is vendored under ios/vendor and compiled into this
   # pod's own Swift module (module_name "BlePlx", matching the "BlePlx-Swift.h" import in


### PR DESCRIPTION
## Summary
- publish the roadmap referenced by package documentation
- align CocoaPods source tags with the v-prefixed GitHub release tag
- update all active release metadata to 3.8.3

## Validation
- pnpm verify:release
- npm pack --dry-run (included in the release gate)