### PR TITLE
chore: release 3.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [3.9.0] - 2026-07-24
+
 ### Added
 
-- `ConnectionManager.attemptConnectOnce` — externally gated single connect for host-owned reconnect policy (mutually exclusive with auto-reconnect per device; strict coalesce).
-- `BleManager.getRestoredState()` — buffered iOS state restoration handoff for late subscribers (coexists with `restoreStateFunction`).
-- Docs: `docs/BACKGROUND.md` restore lifecycle and host-owned resume recipes; gated mode section in `docs/CONNECTION_MANAGER.md`.
-- CI: reusable Apple workflow (`.github/workflows/apple-ci.yml`) and composite actions for Xcode / JS setup (macos-26, Xcode 26.4+).
+- **`ConnectionManager.attemptConnectOnce`** — externally gated single connect for host-owned reconnect policy. Exactly one race-hardened native attempt (timeout / cancel / coalesce); no internal multi-retry and no auto re-arm for that call. Mutually exclusive with auto-reconnect per `deviceId` (strict coalesce: does not join a non-gated in-flight `connect`).
+- **`BleManager.getRestoredState()`** — buffered first iOS `RestoreStateEvent` for late session-layer subscribers. Coexists with `restoreStateFunction` (callback still runs on every emit; buffer is first-only). Identifier-only construction registers the listener (no callback required).
+- **`docs/BACKGROUND.md`** — restore lifecycle, semantics matrix, D5 reporting-only policy, and host resume recipes (gated **A** and opt-in auto **B**).
+- Gated-mode section in **`docs/CONNECTION_MANAGER.md`** (exclusivity table + caller-owned backoff example).
+- CI: reusable Apple workflow (`.github/workflows/apple-ci.yml`) and composite actions (`.github/actions/select-xcode`, `setup-js-package`) for macos-26 / Xcode 26.4+ (CI pin 26.6 for Expo Swift 6.2).
 
 ### Changed
 
-- **iOS Restoration adapter no longer calls `connectToDevice` on system restore** (D5). 3.8.x reconnected restored peripherals inside the adapter; 3.9.0 treats restore as **reporting only** (payload + manager reuse + best-effort cache seed). Hosts must reconnect via `getRestoredState` + `attemptConnectOnce` or an explicit `enableAutoReconnect` recipe — see `docs/BACKGROUND.md`. Intentional correctness fix so reconnect authority is not split under session layers.
+- **iOS Restoration adapter no longer calls `connectToDevice` on system restore (D5).**
+  In 3.8.x the adapter reconnected restored peripherals internally. In 3.9.0 restore is **reporting only**: JS-shaped payload, `BleClientManager` reuse, best-effort native cache seed / disconnect monitors, empty-list wakes still settle `getRestoredState`. Hosts reconnect via `getRestoredState` + `attemptConnectOnce` or an explicit `enableAutoReconnect` recipe — see `docs/BACKGROUND.md`. Intentional correctness fix so reconnect authority is not split under session layers.
+- Empty / whitespace `restoreStateIdentifier` is treated as **unconfigured** (immediate `null` for `getRestoredState`, `createClient(null)`), matching native empty→nil coercion.
+- On the Restoration adapter reuse path, `createClient` **replays** the buffered restore payload and disarms MBA’s synthetic-null restore amb so `restoreStateFunction` does not see a cold-launch `null` after a real restore handoff.
+- `ConnectionManager` cancel / replace: suppress one cancel-induced disconnect for auto-reconnect devices; clear suppress when cancel rejects (no disconnect expected); identity-safe map cleanup so reentrant `connect` / `attemptConnectOnce` from failure callbacks is not deleted; user callbacks isolated from the retry state machine.
+
+### Migration (3.8.x → 3.9.0)
+
+1. **If you relied on silent adapter reconnect after iOS kill/restore:** add an explicit host path after `await manager.getRestoredState()` (recipe A or B in `docs/BACKGROUND.md`). Without that, restored ids are reported but links are not re-established by the library.
+2. **Prefer `getRestoredState()`** for session layers that start after `new BleManager(...)` (constructor `restoreStateFunction` alone still races app boot).
+3. **Use `attemptConnectOnce`** when the host owns backoff / permanent-vs-transient failure policy; use `connect` / `enableAutoReconnect` when the library should own retries after a successful link.
+4. Auto-reconnect **does not** restart after a failed initial connect that never connected (no disconnect event). Kickoff exhaustion must be re-kicked by the host if needed.
 
 ## [3.8.4] - 2026-07-19
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ It supports:
 - Reading RSSI and negotiating MTU
 - Background mode on iOS (including optional state restoration)
 - Android background mode via foreground service
-- [`ConnectionManager`](docs/CONNECTION_MANAGER.md) retry, timeout, and auto-reconnect helpers
+- [`ConnectionManager`](docs/CONNECTION_MANAGER.md) retry, timeout, auto-reconnect, and **`attemptConnectOnce`** (host-owned single attempt)
+- [`getRestoredState()`](docs/BACKGROUND.md) late iOS restore handoff (3.9+) plus constructor `restoreStateFunction`
 - Apple TV / tvOS as a BLE central (see [tvOS notes](docs/TVOS.md))
 
 It does NOT support:
@@ -72,15 +73,22 @@ For older React Native versions, use the upstream [dotintent/react-native-ble-pl
 
 ## Current Branch Status
 
+- **3.9.0** stable line: gated `ConnectionManager.attemptConnectOnce`, `BleManager.getRestoredState()`, reporting-only iOS restore (D5), Apple CI composites.
 - Requires RN 0.86 / Expo SDK 57 and uses the generated TurboModule spec (`NativeBlePlxSpec`).
 - Android registers through `BaseReactPackage` and depends on `react-android`.
 - The Expo example is CNG-first: `example-expo/android` and `example-expo/ios` are generated, not checked in.
 - The Expo config plugin handles BLE permissions, iOS background modes/restoration, Android foreground service metadata, and native debug flags.
 - Public reliability APIs are consolidated on `ConnectionManager`. Legacy `ConnectionQueue` and `ReconnectionManager` modules are removed (use `ConnectionManager` only).
-- Documentation and support are owned in this repository (`docs/` + GitHub Issues).
+- Documentation and support are owned in this repository (`docs/` + GitHub Issues). Full restore recipes: [docs/BACKGROUND.md](docs/BACKGROUND.md).
 - Programmatic Android Bluetooth adapter toggling was removed because it is blocked for normal apps targeting Android 13+.
 
 ## Version History
+
+**3.9.0 (This Fork)**
+
+- Adds `ConnectionManager.attemptConnectOnce` for host-owned reconnect policy (single attempt; mutually exclusive with auto-reconnect).
+- Adds `BleManager.getRestoredState()` for late iOS restore handoff (buffered first payload alongside `restoreStateFunction`).
+- **Breaking for apps that relied on silent adapter reconnect:** iOS Restoration adapter reports restore only (D5) — no `connectToDevice` inside the adapter. Hosts reconnect via `getRestoredState` + gated/auto recipes in `docs/BACKGROUND.md`.
 
 **3.8.4 (This Fork)**
 
@@ -153,11 +161,13 @@ This fork is independently maintained. **Documentation and support live in this 
 | [Fork notes](docs/FORK.md) | What changed vs upstream, floors, and roadmap posture |
 | [Roadmap](ROADMAP.md) | Long-term strategy: reliability, features, native ownership, multiplatform |
 | [Roadmap 4.0](ROADMAP.4.0.md) | Ambitious 4.x charter (alpha, Electron, Web, desktop backends) |
-| [ConnectionManager](docs/CONNECTION_MANAGER.md) | Retry, timeout, and auto-reconnect |
+| [ConnectionManager](docs/CONNECTION_MANAGER.md) | Retry, timeout, auto-reconnect, `attemptConnectOnce` |
+| [Background / iOS restore](docs/BACKGROUND.md) | `getRestoredState`, D5 host reconnect recipes |
 | [Expo config plugin](docs/EXPO_PLUGIN.md) | Plugin options and CNG notes |
 | [tvOS / Apple TV](docs/TVOS.md) | Apple TV support and limits |
 | [Tutorials](docs/TUTORIALS.md) | Extra usage patterns |
 | [Release process](RELEASE.md) | How releases are verified and published |
+| [Changelog](CHANGELOG.md) | Release notes (3.9.0 migration and history) |
 
 **Support:** open an issue on [sfourdrinier/react-native-ble-plx](https://github.com/sfourdrinier/react-native-ble-plx/issues).
 
@@ -239,24 +249,29 @@ Expo SDK 57 targets modern iOS versions. The plugin writes `NSBluetoothAlwaysUsa
 1. If you want to support background mode:
    - In your application target go to `Capabilities` tab and enable `Uses Bluetooth LE Accessories` in
      `Background Modes` section.
-   - Pass `restoreStateIdentifier` and `restoreStateFunction` to `BleManager` constructor.
+   - Pass `restoreStateIdentifier` (and optionally `restoreStateFunction`) to `BleManager`. Prefer **`await manager.getRestoredState()`** for session layers that start after construction — see [docs/BACKGROUND.md](docs/BACKGROUND.md).
 
 #### Optional: iOS BLE State Restoration (Restoration subspec)
 
 - Opt-in via the config plugin: set `iosEnableRestoration: true` and optionally `iosRestorationIdentifier` to a stable string.
 - The plugin writes `BlePlxRestoreIdentifier` into `Info.plist` and injects the `react-native-ble-plx/Restoration` subspec into your Podfile.
-- In JS, pass the same identifier to `BleManager`:
+- In JS, pass the same identifier to `BleManager`. **3.9+:** the adapter **reports** restore only; your app reconnects:
 
 ```ts
 const manager = new BleManager({
   restoreStateIdentifier: 'com.example.myapp.bleplx',
+  // optional constructor callback (can race app boot):
   restoreStateFunction: (restoredState) => {
-    // Rehydrate your app, reconnect devices, etc.
+    console.log('restore callback', restoredState?.connectedPeripherals?.length ?? null)
   },
-});
+})
+
+// Later (session / hub init) — preferred handoff:
+const restored = await manager.getRestoredState()
+// then attemptConnectOnce or enableAutoReconnect — docs/BACKGROUND.md
 ```
 
-- The Restoration subspec exposes a Swift adapter (`BlePlxRestorationAdapter`) that will register with any restoration registry present in the host app (for example, a shared `BleRestorationRegistry`). If no registry is present, it is a no-op.
+- The Restoration subspec exposes a Swift adapter (`BlePlxRestorationAdapter`) that registers with a host restoration registry when present. It does **not** call `connectToDevice` (D5).
 
 ### Android (Manual Setup)
 
@@ -595,7 +610,7 @@ await connectionManager.connect(deviceId, {
 
 ### ConnectionManager (Recommended)
 
-**Unified connection management** with retry logic, timeout support, and automatic reconnection — all in one manager. Full guide: [docs/CONNECTION_MANAGER.md](docs/CONNECTION_MANAGER.md).
+**Unified connection management** with retry logic, timeout support, automatic reconnection, and host-owned gated attempts — all in one manager. Full guide: [docs/CONNECTION_MANAGER.md](docs/CONNECTION_MANAGER.md).
 
 ```typescript
 import { BleManager, ConnectionManager } from '@sfourdrinier/react-native-ble-plx';
@@ -610,6 +625,9 @@ const device = await connectionManager.connect('AA:BB:CC:DD:EE:FF', {
   timeoutMs: 15000,  // Connection timeout
   backoffMultiplier: 2
 });
+
+// Host-owned single attempt (3.9+): no multi-retry / no auto re-arm for this call
+// await connectionManager.attemptConnectOnce(deviceId, { timeoutMs: 15000 });
 
 // Enable auto-reconnect for a device
 connectionManager.enableAutoReconnect('AA:BB:CC:DD:EE:FF', {
@@ -648,7 +666,8 @@ connectionManager.disableAutoReconnect('AA:BB:CC:DD:EE:FF');
 - ✅ Concurrent connections to different devices
 - ✅ Configurable connection timeout (prevents hangs)
 - ✅ Exponential backoff retry logic
-- ✅ Automatic reconnection on unexpected disconnects
+- ✅ Automatic reconnection on unexpected disconnects (after a successful link)
+- ✅ **`attemptConnectOnce`** for host-owned reconnect policy (3.9+)
 - ✅ Comprehensive event callbacks (onConnect, onDisconnect, onConnecting, onConnectFailed)
 - ✅ Clean cancellation and lifecycle management
 

--- a/ROADMAP.4.0.md
+++ b/ROADMAP.4.0.md
@@ -2,11 +2,11 @@
 
 **Status:** living document · ambitious 4.x charter
 **Last updated:** 2026-07
-**Stable line:** 3.8.x (maintenance / critical fixes)
+**Stable line:** **3.9.x** (current production; 3.8.x remains installable for security/critical backports only)
 **Active ambition:** **4.0.0-alpha → 4.0.0 → 4.x**
-**Related:** [ROADMAP.md](./ROADMAP.md) (long-term strategy & multiplatform doctrine)
+**Related:** [ROADMAP.md](./ROADMAP.md) (long-term strategy & multiplatform doctrine) · [CHANGELOG.md](./CHANGELOG.md)
 
-This document is the **product charter for 4.x**. It is intentionally ambitious: 4.x is not “3.9 with bonding.” It is a **new generation**—mobile excellence, owned native core, multi-host preview (React Native, Electron, Web Bluetooth, macOS / Windows / Linux)—shipped with a **hard compatibility guarantee for existing 3.8.x app code**.
+This document is the **product charter for 4.x**. It is intentionally ambitious: 4.x is not “3.9 with bonding.” It is a **new generation**—mobile excellence, owned native core, multi-host preview (React Native, Electron, Web Bluetooth, macOS / Windows / Linux)—shipped with a **hard compatibility guarantee for existing 3.x app code** (including 3.8.x and 3.9.x Base64 call sites).
 
 No calendar dates. Phases are dependency-ordered.
 
@@ -50,8 +50,9 @@ The most **reliable**, **modern**, and **feature-complete** Bluetooth Low Energy
 
 | Line | Policy |
 | ---- | ------ |
-| **3.8.x** | Stable for production; security/critical fixes only |
-| **4.0.0-alpha.\*** | New surfaces land; **compat guarantee still applies** to 3.8-style API; dist-tag `alpha` |
+| **3.9.x** | Current stable production line (gated CM + restore handoff shipped in 3.9.0) |
+| **3.8.x** | Previous stable; security/critical fixes only |
+| **4.0.0-alpha.\*** | New surfaces land; **compat guarantee still applies** to 3.x-style API; dist-tag `alpha` |
 | **4.0.0-beta.\*** | API freeze candidate for new APIs; dual native stack kill date set; matrix rows for declared hosts |
 | **4.0.0** | Mobile production quality + multi-host **preview** + **compat guarantee held** |
 | **4.x** | Multi-host supported; L2CAP/PHY polish; Base64 still available unless 5.0 |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 **Status:** living document  
 **Last updated:** 2026-07  
 **Package floor:** React Native 0.86+, Expo SDK 57+, TypeScript-first TurboModule  
-**Package version at writing:** 3.8.4
+**Package version at writing:** 3.9.0
 
 This roadmap describes how this fork becomes the most modern, reliable, and feature-complete Bluetooth Low Energy library for React Native—and, over time, a multiplatform BLE client (mobile, web, desktop, Linux). It is intentional product planning, not a release schedule. Priorities can shift when real app needs (especially production background reliability) demand it.
 
@@ -417,13 +417,13 @@ Phases are sequential in intent. Some Phase 1 items can ship independently. Phas
 | React hooks layer (`useBluetoothState`, `useScan`, `useDevice`, …) | **P1** | Low | Thin layer over BleManager / ConnectionManager |
 | Global events bus (connection, MTU, bond, services reset) | **P1** | Med | Multi-device telemetry and UIs |
 | Background hardening pass | **P0** | Med | Restore + FGS race fixes, disconnect storms, kill tests, ConnectionManager integration |
-| `ConnectionManager` externally gated mode (host-owned reconnect policy; CM executes attempts) | **P1** | Low | **Implemented** (`attemptConnectOnce`, [#27](https://github.com/sfourdrinier/react-native-ble-plx/issues/27)) — pending 3.9.0 release |
-| First-class `onRestoredState` handoff (restored peripherals as `Device[]` + resume-streams recipe) | **P1** | Med | **Implemented** (`getRestoredState`, BACKGROUND.md, [#27](https://github.com/sfourdrinier/react-native-ble-plx/issues/27)) — pending 3.9.0 release |
+| `ConnectionManager` externally gated mode (host-owned reconnect policy; CM executes attempts) | **P1** | Low | **Shipped in 3.9.0** (`attemptConnectOnce`, [#27](https://github.com/sfourdrinier/react-native-ble-plx/issues/27) / [#29](https://github.com/sfourdrinier/react-native-ble-plx/pull/29)) |
+| First-class `onRestoredState` handoff (restored peripherals as `Device[]` + resume-streams recipe) | **P1** | Med | **Shipped in 3.9.0** (`getRestoredState`, BACKGROUND.md, [#27](https://github.com/sfourdrinier/react-native-ble-plx/issues/27) / [#29](https://github.com/sfourdrinier/react-native-ble-plx/pull/29)) |
 | Example app: background + multi-device scenarios | **P1** | Low | Proof, not just prose |
 
 **Exit criteria:** OTA/services-reset is first-class; multi-device concurrency is documented and default-safe; background matrix is filled for mobile central; hooks are optional but polished.
 
-**Stable-line delivery note (3.9.0):** the externally-gated `ConnectionManager` mode (`attemptConnectOnce`) and the restore handoff (`getRestoredState` + BACKGROUND.md) are **implemented** on the stable line as additive public API for a **3.9.0 minor** ahead of the 4.x train — tracked in [#27](https://github.com/sfourdrinier/react-native-ble-plx/issues/27). Not 3.8.x — per [ROADMAP.4.0.md](./ROADMAP.4.0.md) versioning, 3.8.x is security/critical fixes only. Unit tests + docs land with the feature PR; package version bump / npm publish follow RELEASE.md after merge.
+**Stable-line delivery note (3.9.0):** the externally-gated `ConnectionManager` mode (`attemptConnectOnce`) and the restore handoff (`getRestoredState` + BACKGROUND.md) shipped on the stable line as additive public API in **3.9.0** ([#27](https://github.com/sfourdrinier/react-native-ble-plx/issues/27) / [#29](https://github.com/sfourdrinier/react-native-ble-plx/pull/29)). Not 3.8.x — per [ROADMAP.4.0.md](./ROADMAP.4.0.md) versioning, 3.8.x is security/critical fixes only.
 
 ---
 

--- a/__tests__/PackageModernization.js
+++ b/__tests__/PackageModernization.js
@@ -265,7 +265,11 @@ describe('package modernization targets', () => {
     expect(rootPackage.scripts['verify:release']).toBe('bash scripts/verify-release.sh')
     expect(fs.existsSync(releaseVerifyScriptPath)).toBe(true)
     expect(releaseDoc).toContain('pnpm verify:release')
-    expect(releaseDoc).toContain('Current released version: `3.8.4`')
+    // Current Release block tracks last *published* version (updated after Path A succeeds).
+    // While preparing a release PR, package.json may already be the next version.
+    expect(releaseDoc).toMatch(/Current released version: `\d+\.\d+\.\d+`/)
+    expect(rootPackage.version).toBe('3.9.0')
+    expect(fs.readFileSync(path.join(__dirname, '..', 'CHANGELOG.md'), 'utf8')).toContain('## [3.9.0]')
     expect(releaseDoc).toContain('Expo SDK 57')
     expect(releaseDoc).toContain('React Native 0.86')
     expect(releaseDoc).toContain('pnpm test:package')

--- a/docs/BACKGROUND.md
+++ b/docs/BACKGROUND.md
@@ -1,8 +1,8 @@
 # Background reliability — iOS state restoration handoff
 
-This guide covers **iOS BLE state restoration** for this fork: why constructor-only callbacks race app startup, how `getRestoredState()` works, and host-owned resume recipes (gated or explicit auto).
+**Stable as of 3.9.0.** This guide covers **iOS BLE state restoration** for this fork: why constructor-only callbacks race app startup, how `getRestoredState()` works, and host-owned resume recipes (gated or explicit auto).
 
-For Android foreground service and Expo config, see the root README and [EXPO_PLUGIN.md](./EXPO_PLUGIN.md). For auto-reconnect vs host-owned policy, see [CONNECTION_MANAGER.md](./CONNECTION_MANAGER.md).
+For Android foreground service and Expo config, see the root README and [EXPO_PLUGIN.md](./EXPO_PLUGIN.md). For auto-reconnect vs host-owned policy, see [CONNECTION_MANAGER.md](./CONNECTION_MANAGER.md). See [CHANGELOG.md](../CHANGELOG.md) for the 3.8 → 3.9 migration note (D5 reporting-only restore).
 
 ## Prerequisites (iOS)
 

--- a/docs/CONNECTION_MANAGER.md
+++ b/docs/CONNECTION_MANAGER.md
@@ -1,6 +1,6 @@
 # ConnectionManager
 
-`ConnectionManager` is the supported reliability API for this fork. It unifies connection attempts, exponential backoff retries, timeouts, and automatic reconnection in a **single state machine per device**.
+`ConnectionManager` is the supported reliability API for this fork. It unifies connection attempts, exponential backoff retries, timeouts, automatic reconnection, and (from **3.9.0**) host-owned **`attemptConnectOnce`** gated attempts in a **single state machine per device**.
 
 ## Why it exists
 

--- a/docs/EXPO_PLUGIN.md
+++ b/docs/EXPO_PLUGIN.md
@@ -71,21 +71,31 @@ npx expo run:android
 
 ## JavaScript pairing for restoration
 
-When `iosEnableRestoration` is true, pass the same identifier into `BleManager`:
+When `iosEnableRestoration` is true, pass the same identifier into `BleManager`.
+
+**3.9+:** restoration is **reporting only** (the adapter does not reconnect). Prefer `getRestoredState()` for session layers that start after construction, then apply host reconnect policy:
 
 ```ts
-import { BleManager } from '@sfourdrinier/react-native-ble-plx'
+import { BleManager, ConnectionManager } from '@sfourdrinier/react-native-ble-plx'
 
 const manager = new BleManager({
   restoreStateIdentifier: 'com.example.myapp.bleplx',
+  // optional — can fire before your session layer exists:
   restoreStateFunction: (restoredState) => {
-    // Resume connections / streaming from restored peripherals
+    console.log('restore callback', restoredState?.connectedPeripherals?.length ?? null)
   }
 })
+
+// Later (session init) — preferred:
+const restored = await manager.getRestoredState()
+// recipes: docs/BACKGROUND.md (attemptConnectOnce or enableAutoReconnect)
 ```
+
+Full matrix and recipes: [BACKGROUND.md](./BACKGROUND.md).
 
 ## Related docs
 
+- [Background / iOS restore](./BACKGROUND.md)
 - [Fork notes](./FORK.md)
 - [ConnectionManager](./CONNECTION_MANAGER.md)
 - [tvOS](./TVOS.md)

--- a/docs/FORK.md
+++ b/docs/FORK.md
@@ -9,7 +9,7 @@ This package is a maintained fork of [dotintent/react-native-ble-plx](https://gi
 - **Issues / support:** https://github.com/sfourdrinier/react-native-ble-plx/issues
 - **Docs:** this repository (`docs/` + root `README.md`)
 
-## Supported floors (v3.8+)
+## Supported floors (v3.8+; current stable **3.9.0**)
 
 | Surface | Minimum |
 | ------- | ------- |
@@ -27,10 +27,11 @@ Older RN/Expo versions should stay on upstream or an older fork tag.
 - TypeScript-first public API
 - RN 0.86 codegen TurboModule (`NativeBlePlx` / `BlePlxSpec`)
 - Expo config plugin for permissions, background modes, restoration, Android FGS, debug logging
-- `ConnectionManager` for retries, timeouts, and auto-reconnect
-- Optional iOS BLE state restoration subspec
+- `ConnectionManager` for retries, timeouts, auto-reconnect, and **`attemptConnectOnce`** (3.9+ host-owned single attempt)
+- Optional iOS BLE state restoration subspec with **reporting-only** restore (3.9+ D5) and **`getRestoredState()`** late handoff
 - Android foreground service background BLE
 - Apple TV / tvOS central role support (see [TVOS.md](./TVOS.md))
+- Documented background restore recipes ([BACKGROUND.md](./BACKGROUND.md))
 
 ## What was intentionally removed
 
@@ -55,9 +56,11 @@ This repo is developed and released with **pnpm**.
 ## Related docs
 
 - [Getting started](./GETTING_STARTED.md)
+- [Background / iOS restore](./BACKGROUND.md)
 - [Roadmap](../ROADMAP.md)
 - [Roadmap 4.0](../ROADMAP.4.0.md)
 - [ConnectionManager](./CONNECTION_MANAGER.md)
 - [Expo plugin](./EXPO_PLUGIN.md)
 - [tvOS](./TVOS.md)
 - [Release process](../RELEASE.md)
+- [Changelog](../CHANGELOG.md)

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -4,11 +4,12 @@ This guide introduces the BLE stack and APIs exported by **`@sfourdrinier/react-
 
 For more detail:
 
-- [Fork notes](./FORK.md) — platforms, floors, and what this fork owns
+- [Fork notes](./FORK.md) — platforms, floors, and what this fork owns (current stable **3.9.0**)
 - [Expo config plugin](./EXPO_PLUGIN.md) — plugin options and CNG
-- [ConnectionManager](./CONNECTION_MANAGER.md) — retries, auto-reconnect, and gated single attempts
-- [Background / iOS restoration](./BACKGROUND.md) — `getRestoredState` and resume-streams
+- [ConnectionManager](./CONNECTION_MANAGER.md) — retries, auto-reconnect, and `attemptConnectOnce`
+- [Background / iOS restoration](./BACKGROUND.md) — `getRestoredState` and host resume recipes (D5)
 - [tvOS](./TVOS.md) — Apple TV notes
+- [Changelog](../CHANGELOG.md) — release notes and 3.8 → 3.9 migration
 - [Tutorials](./TUTORIALS.md)
 - Example apps in this repository (`example/`, `example-expo/`)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sfourdrinier/react-native-ble-plx",
-  "version": "3.8.4",
+  "version": "3.9.0",
   "description": "React Native Bluetooth Low Energy library",
   "packageManager": "pnpm@10.14.0",
   "main": "lib/commonjs/index.js",


### PR DESCRIPTION
## Summary

Release **3.9.0** of `@sfourdrinier/react-native-ble-plx` after merging #29.

### Package
- `package.json` version → `3.9.0`

### Changelog
- Dated `## [3.9.0] - 2026-07-24` with **Added**, **Changed**, and **Migration (3.8.x → 3.9.0)**
- Full historical CHANGELOG preserved

### Docs (end-to-end)
- README (features, version history, restore snippets, ConnectionManager)
- `docs/BACKGROUND.md`, `CONNECTION_MANAGER.md`, `EXPO_PLUGIN.md`, `FORK.md`, `GETTING_STARTED.md`
- `ROADMAP.md` / `ROADMAP.4.0.md` — stable line **3.9.x**

### Gate
- `pnpm verify:release` completed successfully (package tests, plugin, lint, prepack, Expo CNG, Android assemble, `npm pack --dry-run` for 3.9.0)

## Publish path (after merge)

Path A per [RELEASE.md](RELEASE.md):

```bash
git checkout master && git pull --ff-only
git tag -a v3.9.0 -m "v3.9.0" HEAD
git push origin v3.9.0
# Approve GitHub Environment `npm` if required → publish.yml
```

`RELEASE.md` Current Release block is updated **after** npm + GitHub Release succeed.

## Test plan
- [x] `pnpm verify:release`
- [x] PackageModernization + ConnectionManager unit tests
- [ ] CI green on this PR
- [ ] After merge: tag `v3.9.0` → Publish to npm workflow green + provenance