### PR TITLE
fix(ios): true opt-in for Restoration subspec + release 3.9.1 (#32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [3.9.1] - 2026-07-24
+
+### Fixed
+
+- **iOS `iosEnableRestoration` is truly opt-in ([#32](https://github.com/sfourdrinier/react-native-ble-plx/issues/32)).** CocoaPods previously default-linked **all** subspecs when installing the root pod, so the Restoration adapter was always compiled even with `iosEnableRestoration: false`. The podspec now sets `default_subspecs = :none`; Restoration is only linked via explicit `pod 'react-native-ble-plx/Restoration'` (what the Expo plugin injects when the flag is true).
+- Expo plugin **removes** sticky Restoration artifacts when the flag is `false` (or flipped true→false): Podfile marker / `…/Restoration` pod line and Info.plist `BlePlxRestoreIdentifier`.
+
+### Migration (3.9.0 → 3.9.1)
+
+If you relied on Restoration **without** setting `iosEnableRestoration: true` (it was accidentally always linked), set the flag and identifier explicitly, match `BleManager` `restoreStateIdentifier`, then rebuild native iOS (`expo prebuild --clean` / `pod install`).
+
+JS `restoreStateIdentifier` remains a **separate** CoreBluetooth restore key (unchanged); the plugin flag only gates the optional Restoration **subspec** + plist identifier.
+
 ## [3.9.0] - 2026-07-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ For older React Native versions, use the upstream [dotintent/react-native-ble-pl
 
 ## Version History
 
+**3.9.1 (This Fork)**
+
+- Fixes iOS restoration **true opt-in**: CocoaPods no longer default-links the Restoration subspec; `iosEnableRestoration: false` leaves Restoration out of the binary, and the Expo plugin strips sticky Podfile/plist artifacts on disable ([#32](https://github.com/sfourdrinier/react-native-ble-plx/issues/32)).
+
 **3.9.0 (This Fork)**
 
 - Adds `ConnectionManager.attemptConnectOnce` for host-owned reconnect policy (single attempt; mutually exclusive with auto-reconnect).
@@ -213,7 +217,7 @@ The plugin provides props for extra customization. Every time you change the pro
 - `neverForLocation` (_boolean_): Set to true only if you can strongly assert that your app never derives physical location from Bluetooth scan results. The location permission will be still required on older Android devices. Note, that some BLE beacons are filtered from the scan results. Android SDK 31+. Default `false`. _WARNING: This parameter is experimental and BLE might not work. Make sure to test before releasing to production._
 - `modes` (_string[]_): Adds iOS `UIBackgroundModes` to the `Info.plist`. Options are: `peripheral`, and `central`. Defaults to undefined.
 - `bluetoothAlwaysPermission` (_string | false_): Sets the iOS `NSBluetoothAlwaysUsageDescription` permission message to the `Info.plist`. Setting `false` will skip adding the permission. Defaults to `Allow $(PRODUCT_NAME) to connect to bluetooth devices`.
-- `iosEnableRestoration` (_boolean_): Opt-in to the iOS BLE state restoration subspec (disabled by default). When true, the Podfile will include `react-native-ble-plx/Restoration` and the adapter will register with a restoration registry if present.
+- `iosEnableRestoration` (_boolean_): **True opt-in** for the iOS BLE state restoration subspec (disabled by default; 3.9.1+ root CocoaPods pod does not default-link subspecs — [#32](https://github.com/sfourdrinier/react-native-ble-plx/issues/32)). When true, injects `react-native-ble-plx/Restoration` and writes `BlePlxRestoreIdentifier`. When false, removes those artifacts.
 - `iosRestorationIdentifier` (_string_): Custom CBCentralManager restoration identifier. Written to `Info.plist` as `BlePlxRestoreIdentifier` and passed to `BleManager` for state restoration. Defaults to `com.reactnativebleplx.restore`.
 - `androidEnableForegroundService` (_boolean_): Enable Android foreground service for background BLE operations. Adds necessary permissions (`FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_CONNECTED_DEVICE`) and service declaration to `AndroidManifest.xml`. Default `false`.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 **Status:** living document  
 **Last updated:** 2026-07  
 **Package floor:** React Native 0.86+, Expo SDK 57+, TypeScript-first TurboModule  
-**Package version at writing:** 3.9.0
+**Package version at writing:** 3.9.1
 
 This roadmap describes how this fork becomes the most modern, reliable, and feature-complete Bluetooth Low Energy library for React Native—and, over time, a multiplatform BLE client (mobile, web, desktop, Linux). It is intentional product planning, not a release schedule. Priorities can shift when real app needs (especially production background reliability) demand it.
 

--- a/__tests__/IosModernization.js
+++ b/__tests__/IosModernization.js
@@ -23,6 +23,18 @@ describe('iOS modernization defaults', () => {
     expect(restorationBlock).not.toMatch(/:tvos/)
   })
 
+  test('Restoration subspec is opt-in only (default_subspecs :none) — #32', () => {
+    // CocoaPods without :none would default-link ALL subspecs on root pod install.
+    expect(podspec).toMatch(/s\.default_subspecs\s*=\s*:none/)
+    // Root source_files must not pull Restoration Swift into the base pod.
+    const rootSourceMatch = podspec.match(/s\.source_files\s*=\s*[^\n]+/)
+    expect(rootSourceMatch).toBeTruthy()
+    expect(rootSourceMatch[0]).not.toMatch(/ios\/Restoration/)
+    expect(podspec).toContain('ios/Restoration/**/*.{h,m,mm,swift}')
+    // Subspec still declared for explicit pod '…/Restoration'
+    expect(podspec).toContain('subspec "Restoration"')
+  })
+
   test('points CocoaPods source metadata at this fork', () => {
     expect(podspec).toContain('https://github.com/sfourdrinier/react-native-ble-plx.git')
     expect(podspec).toContain(':tag => "v#{s.version}"')

--- a/__tests__/PackageModernization.js
+++ b/__tests__/PackageModernization.js
@@ -268,8 +268,9 @@ describe('package modernization targets', () => {
     // Current Release block tracks last *published* version (updated after Path A succeeds).
     // While preparing a release PR, package.json may already be the next version.
     expect(releaseDoc).toMatch(/Current released version: `\d+\.\d+\.\d+`/)
-    expect(rootPackage.version).toBe('3.9.0')
-    expect(fs.readFileSync(path.join(__dirname, '..', 'CHANGELOG.md'), 'utf8')).toContain('## [3.9.0]')
+    expect(rootPackage.version).toBe('3.9.1')
+    expect(fs.readFileSync(path.join(__dirname, '..', 'CHANGELOG.md'), 'utf8')).toContain('## [3.9.1]')
+    expect(fs.readFileSync(path.join(__dirname, '..', 'CHANGELOG.md'), 'utf8')).toMatch(/#32|iosEnableRestoration/)
     expect(releaseDoc).toContain('Expo SDK 57')
     expect(releaseDoc).toContain('React Native 0.86')
     expect(releaseDoc).toContain('pnpm test:package')

--- a/docs/BACKGROUND.md
+++ b/docs/BACKGROUND.md
@@ -6,12 +6,15 @@ For Android foreground service and Expo config, see the root README and [EXPO_PL
 
 ## Prerequisites (iOS)
 
-1. Enable restoration in the Expo config plugin (`iosEnableRestoration: true`) or native Info.plist / background modes as documented in [EXPO_PLUGIN.md](./EXPO_PLUGIN.md).
+1. **Opt in** to the Restoration subspec (3.9.1+: not linked by default — [#32](https://github.com/sfourdrinier/react-native-ble-plx/issues/32)):
+   - Expo: `iosEnableRestoration: true` (and optional `iosRestorationIdentifier`), or
+   - Bare: `pod 'react-native-ble-plx/Restoration', :path => …` plus Info.plist `BlePlxRestoreIdentifier`.
 2. Pass the **same** string as:
-   - plugin `iosRestorationIdentifier`, and
+   - plugin `iosRestorationIdentifier` / `BlePlxRestoreIdentifier`, and
    - `BleManager` option `restoreStateIdentifier`.
 3. Optionally pass `restoreStateFunction` for a constructor-time callback.
 4. Construct `BleManager` **once** with those options (singleton: first constructor wins).
+5. Rebuild native iOS after enabling or disabling the flag (`expo prebuild --clean` / `pod install`).
 
 tvOS does not support CoreBluetooth state restoration. Prefer not setting a restore identifier on pure tvOS apps.
 
@@ -67,7 +70,7 @@ You may omit `restoreStateFunction` and only use `getRestoredState()` (identifie
 | Subsequent events | Immediate | **First** buffered value | Callback still runs every emit with a new mapping |
 | Android + identifier | Yes | usually `null` | Native emits null promptly on `createClient` |
 | tvOS + identifier | May wait until destroy | waiter → `null` on destroy | Do not rely on restore on tvOS |
-| Restoration subspec off + identifier | May wait until destroy | waiter → `null` on destroy | Install Restoration / plugin flag |
+| Restoration subspec off + identifier | May wait until destroy | waiter → `null` on destroy | Opt in: `iosEnableRestoration: true` or explicit `…/Restoration` pod (3.9.1+ root pod does not default-link subspecs) |
 | After `await destroy()` | Immediate | `null` | Means manager dead — **not** “OS restored nothing” |
 
 Always `await manager.destroy()` on teardown so any pending restore waiters settle.

--- a/docs/EXPO_PLUGIN.md
+++ b/docs/EXPO_PLUGIN.md
@@ -32,8 +32,8 @@ Rebuild native projects after any plugin option change (`npx expo prebuild --cle
 | `neverForLocation` | `boolean` | `false` | Android 31+: assert scan results are never used for location. Experimental — test thoroughly. |
 | `modes` | `('central' \| 'peripheral')[]` | `undefined` | iOS `UIBackgroundModes` for Bluetooth. This library is a **central**; `peripheral` only sets the Info.plist background mode key for apps that use other peripheral APIs. |
 | `bluetoothAlwaysPermission` | `string \| false` | Allow `$(PRODUCT_NAME)` to connect to bluetooth devices | iOS `NSBluetoothAlwaysUsageDescription`. Pass `false` to skip. |
-| `iosEnableRestoration` | `boolean` | `false` | Opt in to the iOS `Restoration` CocoaPods subspec and Info.plist restore identifier. **iOS only** (not available on tvOS). |
-| `iosRestorationIdentifier` | `string` | `com.reactnativebleplx.restore` | Value written as `BlePlxRestoreIdentifier`. Must match the `BleManager` `restoreStateIdentifier`. |
+| `iosEnableRestoration` | `boolean` | `false` | **True opt-in** for the iOS `Restoration` CocoaPods subspec (`default_subspecs = :none` on the root pod). When `true`, injects `pod '…/Restoration'` and writes `BlePlxRestoreIdentifier`. When `false`, **removes** those artifacts (including after a prior true→false flip). **iOS only** (not available on tvOS). See [#32](https://github.com/sfourdrinier/react-native-ble-plx/issues/32). |
+| `iosRestorationIdentifier` | `string` | `com.reactnativebleplx.restore` | Value written as `BlePlxRestoreIdentifier` when restoration is enabled. Must match the `BleManager` `restoreStateIdentifier`. |
 | `androidEnableForegroundService` | `boolean` | `false` | Adds FGS permissions and the connected-device foreground service declaration for background BLE. |
 
 ## Example
@@ -71,7 +71,9 @@ npx expo run:android
 
 ## JavaScript pairing for restoration
 
-When `iosEnableRestoration` is true, pass the same identifier into `BleManager`.
+When `iosEnableRestoration` is true, pass the **same** identifier into `BleManager` as `restoreStateIdentifier`.
+
+**Opt-in only (3.9.1+):** the root CocoaPods pod does **not** include Restoration by default. You need the plugin flag (or a manual `pod 'react-native-ble-plx/Restoration'` line) for the adapter to be present. Passing JS `restoreStateIdentifier` alone still configures CoreBluetooth’s restore key on `createClient`, but without the subspec there is no early adapter wake / buffered payload path — see [BACKGROUND.md](./BACKGROUND.md).
 
 **3.9+:** restoration is **reporting only** (the adapter does not reconnect). Prefer `getRestoredState()` for session layers that start after construction, then apply host reconnect policy:
 

--- a/docs/FORK.md
+++ b/docs/FORK.md
@@ -9,7 +9,7 @@ This package is a maintained fork of [dotintent/react-native-ble-plx](https://gi
 - **Issues / support:** https://github.com/sfourdrinier/react-native-ble-plx/issues
 - **Docs:** this repository (`docs/` + root `README.md`)
 
-## Supported floors (v3.8+; current stable **3.9.0**)
+## Supported floors (v3.8+; current stable **3.9.1**)
 
 | Surface | Minimum |
 | ------- | ------- |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sfourdrinier/react-native-ble-plx",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "description": "React Native Bluetooth Low Energy library",
   "packageManager": "pnpm@10.14.0",
   "main": "lib/commonjs/index.js",

--- a/plugin/src/__tests__/withBLERestorationPodfile-test.ts
+++ b/plugin/src/__tests__/withBLERestorationPodfile-test.ts
@@ -1,4 +1,9 @@
-import { injectRestorationPodLine } from '../withBLERestorationPodfile'
+import {
+  clearBlePlxRestoreIdentifier,
+  injectRestorationPodLine,
+  removeRestorationPodLine,
+  setBlePlxRestoreIdentifier
+} from '../withBLERestorationPodfile'
 
 // Podfile without explicit react-native-ble-plx pod line (typical Expo autolinking)
 const SAMPLE_PODFILE_AUTOLINKING = `require_relative '../node_modules/react-native/scripts/react_native_pods'
@@ -110,6 +115,62 @@ describe('withBLERestorationPodfile', () => {
       const initial = injectRestorationPodLine(SAMPLE_PODFILE_EXPLICIT, '@sfourdrinier/react-native-ble-plx')
       const again = injectRestorationPodLine(initial, '@sfourdrinier/react-native-ble-plx')
       expect(again.match(/react-native-ble-plx\/Restoration/g)?.length).toBe(1)
+    })
+  })
+
+  describe('removeRestorationPodLine (true→false flip, #32)', () => {
+    it('removes autolinking marker block after inject', () => {
+      const injected = injectRestorationPodLine(SAMPLE_PODFILE_AUTOLINKING, 'react-native-ble-plx')
+      expect(injected).toContain('# >>> BLEPLX_RESTORATION_SUBSPEC')
+      expect(injected).toContain('/Restoration"')
+
+      const removed = removeRestorationPodLine(injected, 'react-native-ble-plx')
+      expect(removed).not.toContain('# >>> BLEPLX_RESTORATION_SUBSPEC')
+      expect(removed).not.toContain('# <<< BLEPLX_RESTORATION_SUBSPEC')
+      expect(removed).not.toContain('/Restoration')
+      // Core Podfile structure remains
+      expect(removed).toContain('use_native_modules!')
+      expect(removed).toContain('use_react_native!')
+    })
+
+    it('removes explicit Restoration pod line without removing base pod', () => {
+      const injected = injectRestorationPodLine(SAMPLE_PODFILE_EXPLICIT, '@sfourdrinier/react-native-ble-plx')
+      expect(injected).toContain("pod 'react-native-ble-plx/Restoration'")
+
+      const removed = removeRestorationPodLine(injected, '@sfourdrinier/react-native-ble-plx')
+      expect(removed).not.toContain('/Restoration')
+      expect(removed).toContain("pod 'react-native-ble-plx', :path =>")
+    })
+
+    it('is idempotent when Restoration was never injected', () => {
+      const again = removeRestorationPodLine(SAMPLE_PODFILE_AUTOLINKING, 'react-native-ble-plx')
+      expect(again).toContain('use_native_modules!')
+      expect(again).not.toContain('/Restoration')
+    })
+
+    it('supports enable then disable round-trip', () => {
+      const enabled = injectRestorationPodLine(SAMPLE_PODFILE_AUTOLINKING, 'react-native-ble-plx')
+      const disabled = removeRestorationPodLine(enabled, 'react-native-ble-plx')
+      const reenabled = injectRestorationPodLine(disabled, 'react-native-ble-plx')
+      expect(reenabled).toContain('# >>> BLEPLX_RESTORATION_SUBSPEC')
+      expect(reenabled.match(/# >>> BLEPLX_RESTORATION_SUBSPEC/g)?.length).toBe(1)
+    })
+  })
+
+  describe('BlePlxRestoreIdentifier Info.plist helpers', () => {
+    it('sets and clears BlePlxRestoreIdentifier', () => {
+      const withId = setBlePlxRestoreIdentifier({ CFBundleName: 'App' }, 'com.example.bleplx')
+      expect(withId.BlePlxRestoreIdentifier).toBe('com.example.bleplx')
+      expect(withId.CFBundleName).toBe('App')
+
+      const cleared = clearBlePlxRestoreIdentifier(withId)
+      expect(cleared.BlePlxRestoreIdentifier).toBeUndefined()
+      expect(cleared.CFBundleName).toBe('App')
+    })
+
+    it('clear is idempotent when key absent', () => {
+      const cleared = clearBlePlxRestoreIdentifier({ CFBundleName: 'App' })
+      expect(cleared).toEqual({ CFBundleName: 'App' })
     })
   })
 })

--- a/plugin/src/withBLE.ts
+++ b/plugin/src/withBLE.ts
@@ -7,7 +7,11 @@ import { withBLEAndroidForegroundService } from './withBLEAndroidForegroundServi
 import { BackgroundMode, withBLEBackgroundModes } from './withBLEBackgroundModes'
 import { withBluetoothPermissions } from './withBluetoothPermissions'
 import { withBLEDebugLogging } from './withBLEDebugLogging'
-import { withBLERestorationPodfile } from './withBLERestorationPodfile'
+import {
+  clearBlePlxRestoreIdentifier,
+  setBlePlxRestoreIdentifier,
+  withBLERestorationPodfile
+} from './withBLERestorationPodfile'
 import { blePlxPluginDebugLog, isBlePlxPluginDebugEnabled } from './debugLog'
 
 /**
@@ -49,21 +53,35 @@ const withBLE: ConfigPlugin<
   config = withBluetoothPermissions(config, _props)
   config = withBLEBackgroundModes(config, _props.modes || [])
 
+  // Always run so true→false flips strip sticky Podfile/plist artifacts (#32).
   if (iosEnableRestoration) {
     blePlxPluginDebugLog(debugEnabled, '✓ iosEnableRestoration is TRUE - adding Restoration subspec')
     blePlxPluginDebugLog(debugEnabled, 'Setting BlePlxRestoreIdentifier in Info.plist:', iosRestorationIdentifier)
 
-    // Persist the identifier in Info.plist so the Swift adapter can read it
     config = withInfoPlist(config, conf => {
-      conf.modResults.BlePlxRestoreIdentifier = iosRestorationIdentifier
+      conf.modResults = setBlePlxRestoreIdentifier(
+        conf.modResults as Record<string, unknown>,
+        iosRestorationIdentifier
+      ) as typeof conf.modResults
       return conf
     })
 
-    blePlxPluginDebugLog(debugEnabled, 'Calling withBLERestorationPodfile with pkgName:', pkg.name)
-    // Inject Restoration subspec into Podfile
-    config = withBLERestorationPodfile(config, { pkgName: pkg.name })
+    blePlxPluginDebugLog(debugEnabled, 'Calling withBLERestorationPodfile (enable) with pkgName:', pkg.name)
+    config = withBLERestorationPodfile(config, { pkgName: pkg.name, enable: true })
   } else {
-    blePlxPluginDebugLog(debugEnabled, '✗ iosEnableRestoration is FALSE - skipping Restoration subspec')
+    blePlxPluginDebugLog(
+      debugEnabled,
+      '✗ iosEnableRestoration is FALSE - removing Restoration subspec / BlePlxRestoreIdentifier if present'
+    )
+
+    config = withInfoPlist(config, conf => {
+      conf.modResults = clearBlePlxRestoreIdentifier(
+        conf.modResults as Record<string, unknown>
+      ) as typeof conf.modResults
+      return conf
+    })
+
+    config = withBLERestorationPodfile(config, { pkgName: pkg.name, enable: false })
   }
 
   // Android

--- a/plugin/src/withBLERestorationPodfile.ts
+++ b/plugin/src/withBLERestorationPodfile.ts
@@ -83,6 +83,10 @@ function indentBlock(block: string, indent: string): string {
     .join('\n')
 }
 
+/**
+ * Inject opt-in `react-native-ble-plx/Restoration` into a Podfile.
+ * Pure string transform — unit-tested without pod install.
+ */
 export function injectRestorationPodLine(podfile: string, pkgName: string): string {
   if (!podfile) return podfile
   if (podfile.includes(MARKER_START) || podfile.includes(`${toPodName(pkgName)}/Restoration`)) return podfile
@@ -134,10 +138,72 @@ export function injectRestorationPodLine(podfile: string, pkgName: string): stri
   return podfile + '\n\n' + rubySnippet + '\n'
 }
 
-export const withBLERestorationPodfile: ConfigPlugin<{ pkgName: string }> = (config, { pkgName }) =>
+/**
+ * Remove Restoration subspec opt-in from a Podfile (marker block and/or explicit pod lines).
+ * Pure string transform — unit-tested without pod install. Idempotent when already absent.
+ */
+export function removeRestorationPodLine(podfile: string, pkgName: string): string {
+  if (!podfile) return podfile
+
+  const podName = toPodName(pkgName)
+  let result = podfile
+
+  // Remove marked Ruby blocks (autolinking injection) by line scan so indent variants match.
+  const lines = result.split('\n')
+  const out: string[] = []
+  let skipping = false
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (trimmed === MARKER_START) {
+      skipping = true
+      continue
+    }
+    if (skipping) {
+      if (trimmed === MARKER_END) {
+        skipping = false
+      }
+      continue
+    }
+    out.push(line)
+  }
+  result = out.join('\n')
+
+  // Remove explicit Restoration pod lines (monorepo / manual).
+  // Do not remove the base `pod 'react-native-ble-plx', …` line.
+  const explicitRestorationLineRe = new RegExp(
+    `^[ \\t]*pod\\s+['"]${podName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/Restoration['"][^\\n]*\\n?`,
+    'gm'
+  )
+  result = result.replace(explicitRestorationLineRe, '')
+
+  // Collapse accidental triple newlines from removals
+  result = result.replace(/\n{3,}/g, '\n\n')
+
+  return result
+}
+
+/** Info.plist pure helpers for unit tests and withInfoPlist mods. */
+export function setBlePlxRestoreIdentifier(
+  infoPlist: Record<string, unknown>,
+  identifier: string
+): Record<string, unknown> {
+  return { ...infoPlist, BlePlxRestoreIdentifier: identifier }
+}
+
+export function clearBlePlxRestoreIdentifier(infoPlist: Record<string, unknown>): Record<string, unknown> {
+  const next = { ...infoPlist }
+  delete next.BlePlxRestoreIdentifier
+  return next
+}
+
+export const withBLERestorationPodfile: ConfigPlugin<{ pkgName: string; enable: boolean }> = (
+  config,
+  { pkgName, enable }
+) =>
   withPodfile(config, modConfig => {
     const contents = modConfig.modResults.contents
-    const updated = injectRestorationPodLine(contents, pkgName)
-    modConfig.modResults.contents = updated
+    modConfig.modResults.contents = enable
+      ? injectRestorationPodLine(contents, pkgName)
+      : removeRestorationPodLine(contents, pkgName)
     return modConfig
   })

--- a/react-native-ble-plx.podspec
+++ b/react-native-ble-plx.podspec
@@ -24,7 +24,12 @@ Pod::Spec.new do |s|
   s.resource_bundles = { 'BlePlx' => ['ios/PrivacyInfo.xcprivacy'] }
   s.compiler_flags = "-DMULTIPLATFORM_BLE_ADAPTER -fmodules -fcxx-modules"
 
-  # Optional BLE state restoration support (off by default). iOS-only: CoreBluetooth
+  # Without :none, CocoaPods treats ALL subspecs as default dependencies of the root pod,
+  # so `pod 'react-native-ble-plx'` would always link Restoration (#32). Keep Restoration
+  # truly opt-in via `pod 'react-native-ble-plx/Restoration'` (Expo plugin injects that line).
+  s.default_subspecs = :none
+
+  # Optional BLE state restoration support (opt-in only). iOS-only: CoreBluetooth
   # state restoration APIs are API_UNAVAILABLE(tvos). The iOS-only platform on this
   # subspec keeps it out of the tvOS build.
   s.subspec "Restoration" do |ss|


### PR DESCRIPTION
## Summary

Fixes [#32](https://github.com/sfourdrinier/react-native-ble-plx/issues/32): `iosEnableRestoration: false` was ineffective because CocoaPods default-linked **all** subspecs.

### Fix
- `s.default_subspecs = :none` so root install is core-only
- Expo plugin reversible: enable injects `…/Restoration` + `BlePlxRestoreIdentifier`; disable strips both
- Unit tests for podspec contract + inject/remove round-trip
- Docs + CHANGELOG **3.9.1** Fixed/Migration

### Release
Package version **3.9.1**. `pnpm verify:release` green (168 package tests + plugin + Expo CNG + Android assemble + pack 3.9.1).

## Test plan
- [x] `pnpm test:plugin` (26 tests)
- [x] `pnpm test:package` including IosModernization #32 contract
- [x] `pnpm verify:release`
- [ ] After merge: tag `v3.9.1` → Path A publish with provenance