### PR TITLE
fix(ios): strip -fmodules/-fcxx-modules to avoid fmt duplicate symbols (#31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **iOS: strip `-fmodules` / `-fcxx-modules` from podspec `compiler_flags` ([#31](https://github.com/sfourdrinier/react-native-ble-plx/issues/31)).** Those flags caused clang to embed ~180 strong `fmt` symbols into `BlePlx.o` / `BlePlxTurboModule.o`, producing duplicate-symbol link failures when React Native is built from source (`libfmt.a`) — visible on Xcode 26.6, latent on 26.5. Pod still compiles without the flags.
+
 ## [3.9.1] - 2026-07-24
 
 ### Fixed

--- a/react-native-ble-plx.podspec
+++ b/react-native-ble-plx.podspec
@@ -22,7 +22,11 @@ Pod::Spec.new do |s|
   s.module_name  = "BlePlx"
   s.source_files = "ios/*.{h,m,mm}", "ios/vendor/MultiplatformBleAdapter/**/*.swift"
   s.resource_bundles = { 'BlePlx' => ['ios/PrivacyInfo.xcprivacy'] }
-  s.compiler_flags = "-DMULTIPLATFORM_BLE_ADAPTER -fmodules -fcxx-modules"
+  # Do not add -fmodules/-fcxx-modules: under -fcxx-modules, clang can emit fmt
+  # inline functions (via RCT-Folly) as strong definitions in BlePlx.o /
+  # BlePlxTurboModule.o, causing duplicate-symbol link failures when RN is built
+  # from source (libfmt.a). See #31.
+  s.compiler_flags = "-DMULTIPLATFORM_BLE_ADAPTER"
 
   # Without :none, CocoaPods treats ALL subspecs as default dependencies of the root pod,
   # so `pod 'react-native-ble-plx'` would always link Restoration (#32). Keep Restoration
@@ -43,7 +47,7 @@ Pod::Spec.new do |s|
     install_modules_dependencies(s)
   else
     s.dependency "React-Core"
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1 -DMULTIPLATFORM_BLE_ADAPTER -fmodules -fcxx-modules"
+    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1 -DMULTIPLATFORM_BLE_ADAPTER"
     s.pod_target_xcconfig = {
       "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
       "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",


### PR DESCRIPTION
## Summary

Fixes #31 on the **3.9.x** line.

`-fmodules -fcxx-modules` in `react-native-ble-plx.podspec` caused clang to embed ~180 strong `fmt` symbols into `BlePlx.o` / `BlePlxTurboModule.o`. When React Native is built from source (`libfmt.a`), the app link fails with duplicate symbols (Xcode 26.6; latent on 26.5).

**Fix:** remove those flags from both `compiler_flags` sites. Reporter verified the pod still compiles and `nm` shows 0 fmt symbols after the strip.

## Changes

- `react-native-ble-plx.podspec` — drop `-fmodules -fcxx-modules`; comment warning against re-adding
- `CHANGELOG.md` — Unreleased note for 3.9.x

## Test plan

- [x] Static: active podspec code has no `-fmodules` / `-fcxx-modules`
- [ ] CI package job (Ubuntu)
- [ ] CI Apple compile checks (`ci:apple` / Xcode 26.6) — iOS example + Expo iOS
- [ ] CI Expo CNG Android (via workflow_dispatch full run)
- [ ] Reporter confirmation on device archive with `ios.buildReactNativeFromSource: true` (ideal)