### PR TITLE
chore: release 3.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [3.9.2] - 2026-07-24
+
 ### Fixed
 
 - **iOS: strip `-fmodules` / `-fcxx-modules` from podspec `compiler_flags` ([#31](https://github.com/sfourdrinier/react-native-ble-plx/issues/31)).** Those flags caused clang to embed ~180 strong `fmt` symbols into `BlePlx.o` / `BlePlxTurboModule.o`, producing duplicate-symbol link failures when React Native is built from source (`libfmt.a`) — visible on Xcode 26.6, latent on 26.5. Pod still compiles without the flags.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ For older React Native versions, use the upstream [dotintent/react-native-ble-pl
 
 ## Current Branch Status
 
-- **3.9.1** stable line: gated `ConnectionManager.attemptConnectOnce`, `BleManager.getRestoredState()`, reporting-only iOS restore (D5), **true opt-in** Restoration subspec (`iosEnableRestoration`, [#32](https://github.com/sfourdrinier/react-native-ble-plx/issues/32)), Apple CI composites.
+- **3.9.2** stable line: gated `ConnectionManager.attemptConnectOnce`, `BleManager.getRestoredState()`, reporting-only iOS restore (D5), **true opt-in** Restoration subspec (`iosEnableRestoration`, [#32](https://github.com/sfourdrinier/react-native-ble-plx/issues/32)), Apple CI composites; iOS podspec no longer uses `-fmodules`/`-fcxx-modules` (fmt link fix, [#31](https://github.com/sfourdrinier/react-native-ble-plx/issues/31)).
 - Requires RN 0.86 / Expo SDK 57 and uses the generated TurboModule spec (`NativeBlePlxSpec`).
 - Android registers through `BaseReactPackage` and depends on `react-android`.
 - The Expo example is CNG-first: `example-expo/android` and `example-expo/ios` are generated, not checked in.
@@ -83,6 +83,10 @@ For older React Native versions, use the upstream [dotintent/react-native-ble-pl
 - Programmatic Android Bluetooth adapter toggling was removed because it is blocked for normal apps targeting Android 13+.
 
 ## Version History
+
+**3.9.2 (This Fork)**
+
+- Fixes iOS link failures when React Native is built from source: removes `-fmodules` / `-fcxx-modules` from the podspec so clang no longer embeds strong `fmt` symbols into `BlePlx.o` ([#31](https://github.com/sfourdrinier/react-native-ble-plx/issues/31)).
 
 **3.9.1 (This Fork)**
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 **Status:** living document  
 **Last updated:** 2026-07  
 **Package floor:** React Native 0.86+, Expo SDK 57+, TypeScript-first TurboModule  
-**Package version at writing:** 3.9.1
+**Package version at writing:** 3.9.2
 
 This roadmap describes how this fork becomes the most modern, reliable, and feature-complete Bluetooth Low Energy library for React Native—and, over time, a multiplatform BLE client (mobile, web, desktop, Linux). It is intentional product planning, not a release schedule. Priorities can shift when real app needs (especially production background reliability) demand it.
 

--- a/__tests__/PackageModernization.js
+++ b/__tests__/PackageModernization.js
@@ -268,9 +268,9 @@ describe('package modernization targets', () => {
     // Current Release block tracks last *published* version (updated after Path A succeeds).
     // While preparing a release PR, package.json may already be the next version.
     expect(releaseDoc).toMatch(/Current released version: `\d+\.\d+\.\d+`/)
-    expect(rootPackage.version).toBe('3.9.1')
-    expect(fs.readFileSync(path.join(__dirname, '..', 'CHANGELOG.md'), 'utf8')).toContain('## [3.9.1]')
-    expect(fs.readFileSync(path.join(__dirname, '..', 'CHANGELOG.md'), 'utf8')).toMatch(/#32|iosEnableRestoration/)
+    expect(rootPackage.version).toBe('3.9.2')
+    expect(fs.readFileSync(path.join(__dirname, '..', 'CHANGELOG.md'), 'utf8')).toContain('## [3.9.2]')
+    expect(fs.readFileSync(path.join(__dirname, '..', 'CHANGELOG.md'), 'utf8')).toMatch(/#31|fcxx-modules|fmt/)
     expect(releaseDoc).toContain('Expo SDK 57')
     expect(releaseDoc).toContain('React Native 0.86')
     expect(releaseDoc).toContain('pnpm test:package')

--- a/docs/FORK.md
+++ b/docs/FORK.md
@@ -9,7 +9,7 @@ This package is a maintained fork of [dotintent/react-native-ble-plx](https://gi
 - **Issues / support:** https://github.com/sfourdrinier/react-native-ble-plx/issues
 - **Docs:** this repository (`docs/` + root `README.md`)
 
-## Supported floors (v3.8+; current stable **3.9.1**)
+## Supported floors (v3.8+; current stable **3.9.2**)
 
 | Surface | Minimum |
 | ------- | ------- |

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -4,7 +4,7 @@ This guide introduces the BLE stack and APIs exported by **`@sfourdrinier/react-
 
 For more detail:
 
-- [Fork notes](./FORK.md) — platforms, floors, and what this fork owns (current stable **3.9.1**)
+- [Fork notes](./FORK.md) — platforms, floors, and what this fork owns (current stable **3.9.2**)
 - [Expo config plugin](./EXPO_PLUGIN.md) — plugin options and CNG (incl. true opt-in `iosEnableRestoration`)
 - [ConnectionManager](./CONNECTION_MANAGER.md) — retries, auto-reconnect, and `attemptConnectOnce`
 - [Background / iOS restoration](./BACKGROUND.md) — `getRestoredState`, host resume recipes (D5), Restoration subspec opt-in

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sfourdrinier/react-native-ble-plx",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "description": "React Native Bluetooth Low Energy library",
   "packageManager": "pnpm@10.14.0",
   "main": "lib/commonjs/index.js",


### PR DESCRIPTION
## Summary

Release **3.9.2** for the stable 3.9.x line.

- Includes the #31 fix (already on `master` via #35): strip `-fmodules`/`-fcxx-modules` from the iOS podspec to avoid strong `fmt` symbols / duplicate-symbol link failures when RN is built from source.
- Version bump, CHANGELOG dated section, README / docs / package modernization test updates.

## Gate

- Local `pnpm verify:release` passed (package + plugin tests, lint/typecheck, prepack, Expo doctor/prebuild, Android assemble, `npm pack --dry-run`).
- Full CI on the fix branch/PR was green before merge of #35.

## After merge (Path A)

```bash
git checkout master && git pull --ff-only
git tag -a v3.9.2 -m "v3.9.2" HEAD
git push origin v3.9.2
```

Then approve the **npm** environment on the Publish workflow if required.