### PR TITLE
docs: record 3.9.2 as current release

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,15 +4,15 @@ This fork publishes as `@sfourdrinier/react-native-ble-plx`.
 
 ## Current Release
 
-Current released version: `3.9.1`.
+Current released version: `3.9.2`.
 
-- npm package: `@sfourdrinier/react-native-ble-plx@3.9.1`
-- Git tag: `v3.9.1`
-- Source commit: `1a476d265379c4d2229b9fa0ad83580fcd5894c6`
-- GitHub release: `v3.9.1`
+- npm package: `@sfourdrinier/react-native-ble-plx@3.9.2`
+- Git tag: `v3.9.2`
+- Source commit: `b090d35a67ead711c41662dcde3fa379d50e0795`
+- GitHub release: `v3.9.2`
 - Provenance: yes (`dist.attestations` with SLSA provenance v1)
 
-3.9.1 was published from GitHub Actions with [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers/) (OIDC) and [provenance attestations](https://docs.npmjs.com/generating-provenance-statements/). Older versions stay as published; provenance is not retroactive.
+3.9.2 was published from GitHub Actions with [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers/) (OIDC) and [provenance attestations](https://docs.npmjs.com/generating-provenance-statements/). Older versions stay as published; provenance is not retroactive.
 
 ## Two publish paths
 


### PR DESCRIPTION
Post-publish bookkeeping per RELEASE.md: Current Release is now 3.9.2 (`b090d35`, provenance yes).