### PR TITLE
fix(ios): null-safe connect/scan options on New Arch (#99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **iOS New Arch: `connectToDevice` / `startDeviceScan` with omitted or null `options` no longer crashes ([#99](https://github.com/sfourdrinier/react-native-ble-plx/issues/99)).** JS now passes `{}` instead of `null` when options are omitted; native `NSDictionaryFromConnectionOptions` / `NSDictionaryFromScanOptions` null-guard the bridged C++ option wrappers (which cannot represent null and previously segfaulted on `autoConnect()` etc.).
+
 ## [3.9.2] - 2026-07-24
 
 ### Fixed

--- a/__tests__/BleManager.js
+++ b/__tests__/BleManager.js
@@ -395,6 +395,22 @@ test('When BleManager calls connectToDevice equivalent BleModule function should
   expect((await bleManager.connectToDevice('id', {})).id).toBe('id')
 })
 
+// #99: omitted/null options must not reach native as null (iOS New Arch crash).
+test('When BleManager connectToDevice is called without options it passes empty object to BleModule', async () => {
+  Native.BleModule.connectToDevice = jest.fn().mockReturnValue(Promise.resolve({ id: 'id' }))
+  expect(await bleManager.connectToDevice('id')).toBeInstanceOf(Device)
+  expect(Native.BleModule.connectToDevice).toBeCalledWith('id', {})
+  Native.BleModule.connectToDevice.mockClear()
+  expect(await bleManager.connectToDevice('id', null)).toBeInstanceOf(Device)
+  expect(Native.BleModule.connectToDevice).toBeCalledWith('id', {})
+})
+
+test('When BleManager startDeviceScan is called with null options it passes empty object to BleModule', () => {
+  const listener = jest.fn()
+  bleManager.startDeviceScan(null, null, listener)
+  expect(Native.BleModule.startDeviceScan).toBeCalledWith(null, {})
+})
+
 test('When BleManager calls cancelDeviceConnection equivalent BleModule function should be called', async () => {
   Native.BleModule.cancelDeviceConnection = jest.fn().mockReturnValue(Promise.resolve({ id: 'id' }))
   expect(await bleManager.cancelDeviceConnection('id')).toBeInstanceOf(Device)

--- a/__tests__/IosModernization.js
+++ b/__tests__/IosModernization.js
@@ -66,7 +66,7 @@ describe('iOS modernization defaults', () => {
       'state:(RCTPromiseResolveBlock)resolve',
       'startDeviceScan:(NSArray*)filteredUUIDs',
       'options:(JS::NativeBlePlx::ScanOptions &)options',
-      'NSDictionaryFromScanOptions(options)',
+      'NSDictionaryFromScanOptions(&options)',
       'stopDeviceScan:(RCTPromiseResolveBlock)resolve',
       'requestConnectionPriorityForDevice:(NSString*)deviceIdentifier',
       'connectionPriority:(double)connectionPriority',
@@ -76,7 +76,7 @@ describe('iOS modernization defaults', () => {
       'connectedDevices:(NSArray<NSString*>*)serviceUUIDs',
       'connectToDevice:(NSString*)deviceIdentifier',
       'options:(JS::NativeBlePlx::ConnectionOptions &)options',
-      'NSDictionaryFromConnectionOptions(options)',
+      'NSDictionaryFromConnectionOptions(&options)',
       'cancelDeviceConnection:(NSString*)deviceIdentifier',
       'isDeviceConnected:(NSString*)deviceIdentifier',
       'discoverAllServicesAndCharacteristicsForDevice:(NSString*)deviceIdentifier',
@@ -112,5 +112,24 @@ describe('iOS modernization defaults', () => {
     expect(iosImplementation).not.toContain('stopDeviceScan) {')
     expect(iosImplementation).toContain('#else\nRCT_EXPORT_METHOD(startDeviceScan:(NSArray*)filteredUUIDs\n                          options:(NSDictionary*)options')
     expect(iosImplementation).toContain('#else\nRCT_EXPORT_METHOD(connectToDevice:(NSString*)deviceIdentifier\n                          options:(NSDictionary*)options')
+  })
+
+  // #99: null options from JS must not crash New Arch (C++ reference wrappers).
+  test('null-guards optional New Arch options conversion helpers (#99)', () => {
+    expect(iosImplementation).toContain(
+      'static NSDictionary *NSDictionaryFromScanOptions(const JS::NativeBlePlx::ScanOptions *options)'
+    )
+    expect(iosImplementation).toContain(
+      'static NSDictionary *NSDictionaryFromConnectionOptions(const JS::NativeBlePlx::ConnectionOptions *options)'
+    )
+    expect(iosImplementation).toMatch(
+      /NSDictionaryFromScanOptions\(const JS::NativeBlePlx::ScanOptions \*options\)[\s\S]*?if \(options == nullptr\)/
+    )
+    expect(iosImplementation).toMatch(
+      /NSDictionaryFromConnectionOptions\(const JS::NativeBlePlx::ConnectionOptions \*options\)[\s\S]*?if \(options == nullptr\)/
+    )
+    // Call sites take address of the bridged reference so a null wrapper is detectable.
+    expect(iosImplementation).toContain('NSDictionaryFromScanOptions(&options)')
+    expect(iosImplementation).toContain('NSDictionaryFromConnectionOptions(&options)')
   })
 })

--- a/ios/BlePlx.mm
+++ b/ios/BlePlx.mm
@@ -32,25 +32,33 @@ RCT_EXPORT_MODULE();
 static BOOL _hasAttemptedAdapterRegistration = NO;
 
 #ifdef RCT_NEW_ARCH_ENABLED
-static NSDictionary *NSDictionaryFromScanOptions(JS::NativeBlePlx::ScanOptions &options) {
+// JS may pass null for optional options objects (BleManager historically used
+// `options || null`). New Arch bridges those as C++ references that cannot be
+// null-safe — calling methods on a null wrapper segfaults (EXC_BAD_ACCESS).
+// Accept a pointer and treat nullptr as an empty options dictionary.
+// See: https://github.com/sfourdrinier/react-native-ble-plx/issues/99
+static NSDictionary *NSDictionaryFromScanOptions(const JS::NativeBlePlx::ScanOptions *options) {
     NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
+    if (options == nullptr) {
+        return dictionary;
+    }
 
-    auto allowDuplicates = options.allowDuplicates();
+    auto allowDuplicates = options->allowDuplicates();
     if (allowDuplicates.has_value()) {
         dictionary[@"allowDuplicates"] = @(*allowDuplicates);
     }
 
-    auto scanMode = options.scanMode();
+    auto scanMode = options->scanMode();
     if (scanMode.has_value()) {
         dictionary[@"scanMode"] = @(*scanMode);
     }
 
-    auto callbackType = options.callbackType();
+    auto callbackType = options->callbackType();
     if (callbackType.has_value()) {
         dictionary[@"callbackType"] = @(*callbackType);
     }
 
-    auto legacyScan = options.legacyScan();
+    auto legacyScan = options->legacyScan();
     if (legacyScan.has_value()) {
         dictionary[@"legacyScan"] = @(*legacyScan);
     }
@@ -58,25 +66,28 @@ static NSDictionary *NSDictionaryFromScanOptions(JS::NativeBlePlx::ScanOptions &
     return dictionary;
 }
 
-static NSDictionary *NSDictionaryFromConnectionOptions(JS::NativeBlePlx::ConnectionOptions &options) {
+static NSDictionary *NSDictionaryFromConnectionOptions(const JS::NativeBlePlx::ConnectionOptions *options) {
     NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
+    if (options == nullptr) {
+        return dictionary;
+    }
 
-    auto autoConnect = options.autoConnect();
+    auto autoConnect = options->autoConnect();
     if (autoConnect.has_value()) {
         dictionary[@"autoConnect"] = @(*autoConnect);
     }
 
-    auto requestMTU = options.requestMTU();
+    auto requestMTU = options->requestMTU();
     if (requestMTU.has_value()) {
         dictionary[@"requestMTU"] = @(*requestMTU);
     }
 
-    NSString *refreshGatt = options.refreshGatt();
+    NSString *refreshGatt = options->refreshGatt();
     if (refreshGatt != nil) {
         dictionary[@"refreshGatt"] = refreshGatt;
     }
 
-    auto timeout = options.timeout();
+    auto timeout = options->timeout();
     if (timeout.has_value()) {
         dictionary[@"timeout"] = @(*timeout);
     }
@@ -289,7 +300,7 @@ RCT_EXPORT_METHOD(startDeviceScan:(NSArray*)filteredUUIDs
   if (filteredUUIDs == nil || [filteredUUIDs isEqual:[NSNull null]]) {
     filteredUUIDs = @[];
   }
-  [_manager startDeviceScan:filteredUUIDs options:NSDictionaryFromScanOptions(options)];
+  [_manager startDeviceScan:filteredUUIDs options:NSDictionaryFromScanOptions(&options)];
   resolve(nil);
 }
 #else
@@ -374,7 +385,7 @@ RCT_EXPORT_METHOD(connectToDevice:(NSString*)deviceIdentifier
                          resolve:(RCTPromiseResolveBlock)resolve
                          reject:(RCTPromiseRejectBlock)reject) {
     [_manager connectToDevice:deviceIdentifier
-                      options:NSDictionaryFromConnectionOptions(options)
+                      options:NSDictionaryFromConnectionOptions(&options)
                       resolve:resolve
                        reject:reject];
 }
@@ -383,6 +394,9 @@ RCT_EXPORT_METHOD(connectToDevice:(NSString*)deviceIdentifier
                           options:(NSDictionary*)options
                          resolve:(RCTPromiseResolveBlock)resolve
                          reject:(RCTPromiseRejectBlock)reject) {
+    if (options == nil || [options isEqual:[NSNull null]]) {
+        options = @{};
+    }
     [_manager connectToDevice:deviceIdentifier
                       options:options
                       resolve:resolve

--- a/src/BleManager.ts
+++ b/src/BleManager.ts
@@ -427,7 +427,10 @@ export class BleManager {
 
     this._scanEventSubscription = this._eventEmitter.addListener(BleModule.ScanEvent, scanListener)
 
-    return this._callPromise(BleModule.startDeviceScan(UUIDs || null, options || null))
+    // Pass {} rather than null: New Arch iOS bridges null options as a C++
+    // reference that cannot be null-checked safely (#99). Empty object is
+    // equivalent to "no options" on all platforms.
+    return this._callPromise(BleModule.startDeviceScan(UUIDs || null, options ?? {}))
   }
 
   /**
@@ -540,7 +543,9 @@ export class BleManager {
     if (Platform.OS === 'android' && (await this.isDeviceConnected(deviceIdentifier))) {
       await this.cancelDeviceConnection(deviceIdentifier)
     }
-    const nativeDevice = await this._callPromise(BleModule.connectToDevice(deviceIdentifier, options || null))
+    // Pass {} rather than null: New Arch iOS segfaults on null ConnectionOptions
+    // (EXC_BAD_ACCESS in NSDictionaryFromConnectionOptions). See #99.
+    const nativeDevice = await this._callPromise(BleModule.connectToDevice(deviceIdentifier, options ?? {}))
     return new Device(nativeDevice, this)
   }
 
@@ -1403,7 +1408,7 @@ export class BleManager {
       )
       return true
     }
-    return this._callPromise(BleModule.enableBackgroundMode(options || null))
+    return this._callPromise(BleModule.enableBackgroundMode(options ?? {}))
   }
 
   /**
@@ -1445,7 +1450,7 @@ export class BleManager {
     if (isIOS) {
       return true
     }
-    return this._callPromise(BleModule.updateBackgroundNotification(options || null))
+    return this._callPromise(BleModule.updateBackgroundNotification(options ?? {}))
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes [#99](https://github.com/sfourdrinier/react-native-ble-plx/issues/99): on iOS New Architecture, `bleManager.connectToDevice(id)` (omitted or null `options`) segfaults in `NSDictionaryFromConnectionOptions` because the TurboModule bridge represents optional option objects as C++ references that cannot be null.

Same shape existed for `startDeviceScan` options.

### Changes

1. **JS (`BleManager`)** — pass `options ?? {}` instead of `options || null` for:
   - `connectToDevice`
   - `startDeviceScan`
   - `enableBackgroundMode` / `updateBackgroundNotification` (same pattern)
2. **iOS New Arch (`BlePlx.mm`)** — conversion helpers take a pointer, return `{}` when `nullptr`, call sites use `&options`.
3. **Old Arch** — normalize nil/`NSNull` connection options to `@{}` (scan already did this).
4. **Tests + CHANGELOG** — unit coverage for omitted/null options → `{}`, structural tests for the native null-guards.

### Workaround (pre-release)

```js
manager.connectToDevice(id, {}) // instead of connectToDevice(id)
```

## Test plan

- [x] `pnpm test:package` (171 tests)
- [x] `pnpm typecheck`
- [ ] Device verification (optional): New Arch iOS app, `connectToDevice(id)` with no options and with `{}` / timeout options