### PR TITLE
chore: release 3.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [3.9.3] - 2026-07-28
+
 ### Fixed
 
 - **iOS New Arch: `connectToDevice` / `startDeviceScan` with omitted or null `options` no longer crashes ([#99](https://github.com/sfourdrinier/react-native-ble-plx/issues/99)).** JS now passes `{}` instead of `null` when options are omitted; native `NSDictionaryFromConnectionOptions` / `NSDictionaryFromScanOptions` null-guard the bridged C++ option wrappers (which cannot represent null and previously segfaulted on `autoConnect()` etc.).

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ For older React Native versions, use the upstream [dotintent/react-native-ble-pl
 
 ## Current Branch Status
 
-- **3.9.2** stable line: gated `ConnectionManager.attemptConnectOnce`, `BleManager.getRestoredState()`, reporting-only iOS restore (D5), **true opt-in** Restoration subspec (`iosEnableRestoration`, [#32](https://github.com/sfourdrinier/react-native-ble-plx/issues/32)), Apple CI composites; iOS podspec no longer uses `-fmodules`/`-fcxx-modules` (fmt link fix, [#31](https://github.com/sfourdrinier/react-native-ble-plx/issues/31)).
+- **3.9.3** stable line: gated `ConnectionManager.attemptConnectOnce`, `BleManager.getRestoredState()`, reporting-only iOS restore (D5), **true opt-in** Restoration subspec (`iosEnableRestoration`, [#32](https://github.com/sfourdrinier/react-native-ble-plx/issues/32)), Apple CI composites; iOS podspec no longer uses `-fmodules`/`-fcxx-modules` (fmt link fix, [#31](https://github.com/sfourdrinier/react-native-ble-plx/issues/31)); New Arch null `options` crash fix ([#99](https://github.com/sfourdrinier/react-native-ble-plx/issues/99)).
 - Requires RN 0.86 / Expo SDK 57 and uses the generated TurboModule spec (`NativeBlePlxSpec`).
 - Android registers through `BaseReactPackage` and depends on `react-android`.
 - The Expo example is CNG-first: `example-expo/android` and `example-expo/ios` are generated, not checked in.
@@ -83,6 +83,10 @@ For older React Native versions, use the upstream [dotintent/react-native-ble-pl
 - Programmatic Android Bluetooth adapter toggling was removed because it is blocked for normal apps targeting Android 13+.
 
 ## Version History
+
+**3.9.3 (This Fork)**
+
+- Fixes iOS New Architecture crash when `connectToDevice` / `startDeviceScan` are called with omitted or null `options` (`EXC_BAD_ACCESS` in options conversion helpers) ([#99](https://github.com/sfourdrinier/react-native-ble-plx/issues/99)).
 
 **3.9.2 (This Fork)**
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 **Status:** living document  
 **Last updated:** 2026-07  
 **Package floor:** React Native 0.86+, Expo SDK 57+, TypeScript-first TurboModule  
-**Package version at writing:** 3.9.2
+**Package version at writing:** 3.9.3
 
 This roadmap describes how this fork becomes the most modern, reliable, and feature-complete Bluetooth Low Energy library for React Native—and, over time, a multiplatform BLE client (mobile, web, desktop, Linux). It is intentional product planning, not a release schedule. Priorities can shift when real app needs (especially production background reliability) demand it.
 

--- a/__tests__/PackageModernization.js
+++ b/__tests__/PackageModernization.js
@@ -268,9 +268,9 @@ describe('package modernization targets', () => {
     // Current Release block tracks last *published* version (updated after Path A succeeds).
     // While preparing a release PR, package.json may already be the next version.
     expect(releaseDoc).toMatch(/Current released version: `\d+\.\d+\.\d+`/)
-    expect(rootPackage.version).toBe('3.9.2')
-    expect(fs.readFileSync(path.join(__dirname, '..', 'CHANGELOG.md'), 'utf8')).toContain('## [3.9.2]')
-    expect(fs.readFileSync(path.join(__dirname, '..', 'CHANGELOG.md'), 'utf8')).toMatch(/#31|fcxx-modules|fmt/)
+    expect(rootPackage.version).toBe('3.9.3')
+    expect(fs.readFileSync(path.join(__dirname, '..', 'CHANGELOG.md'), 'utf8')).toContain('## [3.9.3]')
+    expect(fs.readFileSync(path.join(__dirname, '..', 'CHANGELOG.md'), 'utf8')).toMatch(/#99|null.*options|NSDictionaryFromConnectionOptions/)
     expect(releaseDoc).toContain('Expo SDK 57')
     expect(releaseDoc).toContain('React Native 0.86')
     expect(releaseDoc).toContain('pnpm test:package')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sfourdrinier/react-native-ble-plx",
-  "version": "3.9.2",
+  "version": "3.9.3",
   "description": "React Native Bluetooth Low Energy library",
   "packageManager": "pnpm@10.14.0",
   "main": "lib/commonjs/index.js",


### PR DESCRIPTION
## Summary

Release **3.9.3** containing the iOS New Architecture null-`options` crash fix from [#100](https://github.com/sfourdrinier/react-native-ble-plx/pull/100) / [#99](https://github.com/sfourdrinier/react-native-ble-plx/issues/99).

### Surfaces updated
- `package.json` → `3.9.3`
- `CHANGELOG.md` dated section for 3.9.3
- `README.md` version history / branch status
- `ROADMAP.md` package version at writing
- `PackageModernization` version pin

### Gate
- [x] `pnpm verify:release` (local; package/plugin tests, lint, prepack, Expo doctor/prebuild, Android assembleDebug, npm pack dry-run)

### After merge
Path A: annotated tag `v3.9.3` → `publish.yml` (OIDC + provenance + GitHub Release).